### PR TITLE
docs: update AGENTS.md and CONTRIBUTING.md after tooling changes (#131)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,21 +9,31 @@ This file provides guidance to OpenCode when working with code in this repositor
 ## Commands
 
 ```bash
-npm run check              # Run all checks (lint, prettier, build, test)
-npm run test               # Run tests (uses --experimental-vm-modules for ESM)
-npm run test -- --testPathPattern='<pattern>'  # Run a specific test file
-npm run lint:check         # ESLint (zero warnings allowed)
+npm run check:all          # Run static checks (lint, prettier, types)
+npm run build              # Compile TypeScript (outputs to dist/)
+npm run clean              # Remove dist/
+npm run test               # Run tests with Vitest (default TS version)
+npm run test:ts5           # Run tests with TypeScript 5.x
+npm run test:ts7           # Run tests with TypeScript 7.x
+npm run test:all           # Run tests against all supported TS versions
+npm run test -- <pattern>  # Run a specific test file (Vitest filter)
+npm run types:check        # TypeScript type check only (no emit)
+npm run lint:check         # ESLint (zero warnings allowed, flat config)
 npm run prettier:check     # Check formatting
-npm run package            # Compile TypeScript (outputs to dist/)
 npm run license:check      # Verify MIT headers on src/ files
 ```
 
 Fix variants: `npm run lint:fix`, `npm run prettier:fix`, `npm run license:fix`
 
+Vitest test filter options: use `npm run test -- <pattern>` for file name
+matching, or `npm run test -- -t "<test name>"` for test name matching.
+
 ## Architecture
 
 - **`src/ActRunner.ts`** — Main public API. Fluent builder that configures workflow execution parameters and translates them to `act` CLI arguments via `ActRunnerParams`.
 - **`src/ActWorkflowExecResult.ts`** / **`ActJobExecResult.ts`** — Result objects returned by `ActRunner.run()`. Workflow result contains a map of job results.
+- **`src/ActExecStatus.ts`** — Enum of possible execution statuses: `SUCCESS`, `FAILED`, `SKIPPED`.
+- **`src/ActRunnerError.ts`** — Custom error class for runner errors.
 - **`src/internal/`** — Output parsing via listener pattern. `JobTrackingActExecListener` parses `act` stdout to extract job names and statuses. `OutputForwardingActExecListener` wraps it to also forward output to console.
 - **`src/utils/`** — Validation (`checks.ts`), temp file creation (`fsutils.ts`), and object helpers (`objects.ts`).
 - **`src/index.ts`** — Public exports: `ActRunner`, `ActWorkflowExecResult`, `ActJobExecResult`, `ActExecStatus`, `ActRunnerError`.
@@ -31,7 +41,9 @@ Fix variants: `npm run lint:fix`, `npm run prettier:fix`, `npm run license:fix`
 ## Key Constraints
 
 - **ESM-only** — `"type": "module"` in package.json. Use `.js` extensions in TypeScript imports.
-- **Tests run sequentially** — `maxWorkers: 1` in Jest config because `act` runner invocations cannot be parallelized.
-- **Test timeout is 30s** — workflow execution tests need time for `act` to run.
+- **Tests run sequentially** — `fileParallelism: false` in Vitest config because `act` runner invocations cannot be parallelized.
+- **Test timeout is 50s** — workflow execution tests need time for `act` to run.
 - **All source files require MIT license headers** — enforced by `addlicense` tool.
 - **TypeScript strict mode** — `noImplicitAny`, `noUnusedLocals`, `noUnusedParameters` enabled.
+- **Multi-TS-version testing** — tests run against TypeScript 5.x, 6.x, and 7.x via `TS_VERSION` env var.
+- **Node.js engine** — `^22.23.1 || ^24.0.0 || >=26.0.0` with npm `10.9.8` (engine-strict enabled).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,41 @@ To install dependencies:
 npm install
 ```
 
-To run verification tasks:
+To run static checks (lint, formatting, types):
 
 ```bash
-npm run check
+npm run check:all
+```
+
+To compile TypeScript:
+
+```bash
+npm run build
+npm run clean # remove dist/
+```
+
+To run tests:
+
+```bash
+npm run test             # default TypeScript version (6.x)
+npm run test:ts5         # TypeScript 5.x
+npm run test:ts7         # TypeScript 7.x
+npm run test:all         # all supported versions
+npm run test -- <pattern>  # filter by file name
+npm run test -- -t "<name>"  # filter by test name
+```
+
+To auto-fix issues:
+
+```bash
+npm run lint:fix
+npm run prettier:fix
+npm run license:fix
 ```
 
 ## OpenCode setup
 
-This repository uses [OpenCode](https://opencode.ai) for AI-assisted development. Project instructions are defined in `AGENTS.md`.
+This repository uses [OpenCode](https://opencode.ai) for AI-assisted
+development. Project instructions are defined in `AGENTS.md`. Additional
+OpenCode-specific configuration lives in `.opencode/`:
+instructions, and skills for common workflows.


### PR DESCRIPTION
## Summary

- Replace stale `npm run check`/`npm run package` commands with current `check:all`/`build`/`clean`/`types:check`
- Add multi-TS-version test commands (`test:ts5`, `test:ts7`, `test:all`) and Vitest filter examples
- Correct Jest references to Vitest (fileParallelism, timeout 50s)
- Add missing `ActExecStatus.ts` and `ActRunnerError.ts` to architecture section
- Document Node.js/npm engine constraints
- Expand CONTRIBUTING.md with all development commands

## Test Plan

- [x] Verified all listed commands exist in package.json scripts
- [x] Verified architecture entries match actual source files