### PR TITLE
chore: update renovate config to pin node and lock TS test versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "rangeStrategy": "replace"
+  "rangeStrategy": "replace",
+  "constraints": {
+    "node": "22.23.1"
+  },
+  "packageRules": [
+    {
+      "description": "Lock typescript-5 to TypeScript 5.x",
+      "matchDepNames": ["typescript-5"],
+      "allowedVersions": "^5.0.0"
+    },
+    {
+      "description": "Lock typescript-7 to TypeScript 7.x",
+      "matchDepNames": ["typescript-7"],
+      "allowedVersions": "^7.0.0"
+    }
+  ]
 }


### PR DESCRIPTION
Updates renovate.json to:

- Lock Node.js to earliest supported version (22.23.1) via `constraints`
- Restrict `typescript-5` to TypeScript 5.x range
- Restrict `typescript-7` to TypeScript 7.x range