### PR TITLE
build: enforce license header checks with ESLint

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 original authors
+Copyright (c) 2026 original authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 import prettier from 'eslint-plugin-prettier';
 import globals from 'globals';
+// @ts-expect-error - plugin ships no types
 import headerPlugin from 'eslint-plugin-yet-another-license-header';
 
 const licenseHeader = `

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -6,7 +6,7 @@ import headerPlugin from 'eslint-plugin-yet-another-license-header';
 
 const licenseHeader = `
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -2,29 +2,64 @@ import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 import prettier from 'eslint-plugin-prettier';
 import globals from 'globals';
+import headerPlugin from 'eslint-plugin-yet-another-license-header';
 
-export default defineConfig({
-  files: ['**/*.ts', '**/*.tsx'],
-  ignores: ['dist/**', 'node_modules/**'],
-  languageOptions: {
-    parser: tseslint.parser,
-    parserOptions: {
-      projectService: true,
-      ecmaVersion: 'latest',
-      sourceType: 'module',
+const licenseHeader = `
+/**
+ * Copyright (c) 2025 original authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+`;
+
+export default defineConfig([
+  {
+    ignores: ['dist/**', 'node_modules/**'],
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: true,
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+      globals: {
+        ...globals.node,
+      },
     },
-    globals: {
-      ...globals.node,
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+      prettier,
+      'yet-another-license-header': headerPlugin,
+    },
+    rules: {
+      'no-unused-vars': 'off',
+      'no-debugger': 'warn',
+      'prettier/prettier': 'error',
+      '@typescript-eslint/no-unused-vars': 'warn',
     },
   },
-  plugins: {
-    '@typescript-eslint': tseslint.plugin,
-    prettier,
+  {
+    files: ['src/**/*.ts', 'src/**/*.tsx'],
+    rules: {
+      'yet-another-license-header/header': ['error', { header: licenseHeader }],
+    },
   },
-  rules: {
-    'no-unused-vars': 'off',
-    'no-debugger': 'warn',
-    'prettier/prettier': 'error',
-    '@typescript-eslint/no-unused-vars': 'warn',
-  },
-});
+]);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint": "10.8.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
+    "eslint-plugin-yet-another-license-header": "^1.0.0",
     "globals": "^17.7.0",
     "prettier": "^3.9.6",
     "typescript": "^6.0.3",
@@ -47,20 +48,18 @@
     "typescript": "^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.package.json",
     "clean": "rm -r dist",
-    "lint:fix": "eslint .",
-    "prettier:fix": "prettier --write .",
-    "license:fix": "addlicense -c \"original authors\" -l mit -v src/",
+    "build": "tsc --project tsconfig.package.json",
     "lint:check": "eslint . --max-warnings 0 --flag unstable_native_nodejs_ts_config",
+    "lint:fix": "eslint . --fix --flag unstable_native_nodejs_ts_config",
     "prettier:check": "prettier --check .",
-    "license:check": "addlicense -check src/",
+    "prettier:fix": "prettier --write .",
     "types:check": "tsc --project tsconfig.check.json",
+    "check:all": "pnpm run lint:check && pnpm run prettier:check && pnpm run types:check",
     "test": "TS_VERSION=typescript vitest run",
     "test:ts5": "TS_VERSION=typescript-5 vitest run",
     "test:ts7": "TS_VERSION=typescript-7 vitest run",
-    "test:all": "pnpm run test && pnpm run test:ts5 && pnpm run test:ts7",
-    "check:all": "pnpm run lint:check && pnpm run prettier:check && pnpm run types:check"
+    "test:all": "pnpm run test && pnpm run test:ts5 && pnpm run test:ts7"
   },
   "engines": {
     "node": "^22.23.1 || ^24.0.0 || >=26.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.6
         version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.0))(eslint@10.8.0)(prettier@3.9.6)
+      eslint-plugin-yet-another-license-header:
+        specifier: ^1.0.0
+        version: 1.0.0
       globals:
         specifier: ^17.7.0
         version: 17.7.0
@@ -536,6 +539,10 @@ packages:
         optional: true
       eslint-config-prettier:
         optional: true
+
+  eslint-plugin-yet-another-license-header@1.0.0:
+    resolution: {integrity: sha512-I/qq7aJdKnaf0LDRtQj+6LrMCEbngJBOL8at0qqhXBI2xXGB0skcvT8i3DVs5zQ/wuzNUJNGd7nGnE4+rVAZug==}
+    engines: {node: ^18.18.0 || >=20.9.0}
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -1419,6 +1426,8 @@ snapshots:
       synckit: 0.11.13
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@10.8.0)
+
+  eslint-plugin-yet-another-license-header@1.0.0: {}
 
   eslint-scope@9.1.2:
     dependencies:

--- a/src/ActExecStatus.ts
+++ b/src/ActExecStatus.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/ActJobExecResult.ts
+++ b/src/ActJobExecResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/ActRunnerError.ts
+++ b/src/ActRunnerError.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/ActWorkflowExecResult.ts
+++ b/src/ActWorkflowExecResult.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/internal/ActExecListener.ts
+++ b/src/internal/ActExecListener.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/internal/ActJobExecResultBuilder.ts
+++ b/src/internal/ActJobExecResultBuilder.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/internal/ActResourceSpec.ts
+++ b/src/internal/ActResourceSpec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/internal/JobTrackingActExecListener.ts
+++ b/src/internal/JobTrackingActExecListener.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/internal/OutputForwardingActExecListener.ts
+++ b/src/internal/OutputForwardingActExecListener.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/utils/checks.ts
+++ b/src/utils/checks.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/utils/fsutils.ts
+++ b/src/utils/fsutils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/utils/objects.ts
+++ b/src/utils/objects.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,23 +1,22 @@
 /**
- * Copyright (c) 2026 original authors
+ * Copyright (c) 2025 original authors
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 export type PartialDeep<T> = T extends object

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 original authors
+ * Copyright (c) 2026 original authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Implement ESLint rules to enforce license headers in the codebase and update the year in the license header to 2026. 