### PR TITLE
refactor: remove noise log around creating temporary files

### DIFF
--- a/src/utils/fsutils.ts
+++ b/src/utils/fsutils.ts
@@ -30,7 +30,6 @@ export function createTempWorkflowFile(
   workflowBody: string,
 ): string {
   const fileName = join(workingDir, 'workflow.yml');
-  console.log(`Writing workflow body to file ${fileName}`);
   writeFileSync(fileName, workflowBody);
   return fileName;
 }
@@ -40,7 +39,6 @@ export function createTempEventPayloadFile(
   eventPayloadBody: PartialDeep<WebhookEvent>,
 ): string {
   const fileName = join(workingDir, 'event.json');
-  console.log(`Writing event payload body to file ${fileName}`);
   writeFileSync(fileName, JSON.stringify(eventPayloadBody));
   return fileName;
 }


### PR DESCRIPTION
## Description

These logs are noisy and not actionable. This is especially bad with jest and vitest wrapping the `console.log`. I don't think they add much value.