### PR TITLE
feat: move @octokit/webhooks-types to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
+    "@octokit/webhooks-types": ">=4.0.0 <8.0.0",
     "typescript": "^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0"
   },
   "scripts": {


### PR DESCRIPTION
Currently @octokit/webhooks-types are not auto-installed when you install act-test-runner package and you don't get nice auto-completion when describing event payload. By moving it to peerDependencies and also making them optional we achieve the following behaviour:

1. If user has @octokit/webhooks-types installed, this version will be used
2. If they haven't version 7 will be auto-installed (we can not stick to version 7 and just install the latest one, but I'm not sure it's a good practice).

Currently both npm and pnpm support peerDependencies auto-installing. I'm not quite sure about Yarn, but it's better than the previous behaviour.