### PR TITLE
feat: support supplying a custom act executable

### DIFF
--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -56,6 +56,7 @@ export class ActRunner<
   TEventType extends WebhookEventName | undefined = undefined,
   TEventPayload extends EventPayload<TEventType> = undefined,
 > {
+  private actExecutable: string | undefined;
   private workingDir: string | undefined;
   private workflowFile: string | undefined;
   private workflowBody: string | undefined;
@@ -74,6 +75,16 @@ export class ActRunner<
   private artifactServer: ActResourceSpec | undefined;
   private additionalArgs: string[] = [];
   private shouldForwardOutput: boolean = false;
+
+  /**
+   * Sets the path to the `act` executable (default: `act` binary on the `PATH`).
+   * Useful in the CI environments, where the executable is provisioned on demand in a controlled location.
+   * @param actExecutable - path to the `act` executable.
+   */
+  withActExecutable(actExecutable: string): this {
+    this.actExecutable = actExecutable;
+    return this;
+  }
 
   /**
    * Sets the directory to use for the runner's storage needs (default: directory in user's temp folder).
@@ -268,7 +279,7 @@ export class ActRunner<
             )
           : new JobTrackingActExecListener();
 
-        const process = spawn('act', params.asCliArgs());
+        const process = spawn(this.actExecutable ?? 'act', params.asCliArgs());
 
         process.stdout.on('data', (data) =>
           executionListener.onStdOutput(data.toString().trimEnd()),
@@ -301,6 +312,10 @@ export class ActRunner<
   }
 
   private validateRunnerParams(): ActRunnerParams<TEventType> {
+    if (this.actExecutable) {
+      checkExists('act executable', this.actExecutable);
+    }
+
     const workingDir = checkExists(
       'working directory',
       firstDefined(() => this.workingDir, createTempDir),

--- a/tests/custom_executable.test.ts
+++ b/tests/custom_executable.test.ts
@@ -1,0 +1,47 @@
+import { test, expect, beforeEach, afterEach } from 'vitest';
+import { ActExecStatus, ActWorkflowExecResult } from '../src/index.js';
+import { runner, workflowPath } from './fixtures.js';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+
+export async function run(executable: string): Promise<ActWorkflowExecResult> {
+  return runner()
+    .withActExecutable(executable)
+    .withWorkflowFile(workflowPath('always_passing_workflow'))
+    .run();
+}
+
+const customExecDir = join(tmpdir(), 'actTestRunner', 'custom_executable');
+beforeEach(() => {
+  if (!existsSync(customExecDir)) {
+    mkdirSync(customExecDir, { recursive: true });
+  }
+});
+
+afterEach(() => {
+  if (existsSync(customExecDir)) {
+    rmSync(customExecDir, { recursive: true, force: true });
+  }
+});
+
+test('fails if the supplied custom executable does not exist', async () => {
+  await expect(run('non-existing')).rejects.toThrow(
+    "The specified act executable 'non-existing' does not exist",
+  );
+});
+
+test('runs workflow files with the supplied custom executable', async () => {
+  const customExec = join(customExecDir, 'customAct');
+  writeFileSync(
+    customExec,
+    `#!/usr/bin/env bash
+    echo "Hello from custom act exec!"
+  `,
+    { mode: 0o744 },
+  );
+  const result = await run(customExec);
+
+  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result.output).toContain('Hello from custom act exec');
+});


### PR DESCRIPTION
In ephemeral CI environments, it may make sense to download act on-demand to a controlled location. The previous implementation would require modifying the PATH env variable to make the "act" binary available. This commit allows running act directly from a custom location without manipulating the PATH.
