### PR TITLE
pshevche/150 custom act executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,11 @@ jobs:
 
 ### Sequential runner invocations
 
-Currently, `act` command has a state shared between invocations.
-Invoking `act` in-parallel (e.g. to evaluate multiple workflows) may result in a polluted state and as a result flaky
-workflow executions.
+Currently, tests using `act` can't be reliably invoked in parallel.
+This is caused by `act` generating stable container names based on the workflow's `name` property.
+If your tests run in-parallel and reuse the same workflow file, then the generated container names will collide, resuling in test failures.
+If you still want to run your tests concurrently, ensure that the workflows have unique names.
+See [nektos/act#1287](https://github.com/nektos/act/issues/1287) for mode details.
 
 ### Supported `act` options
 

--- a/src/ActExecStatus.ts
+++ b/src/ActExecStatus.ts
@@ -23,7 +23,7 @@
  * Outcome of the workflow or job execution.
  */
 export enum ActExecStatus {
-  SUCCESS,
-  FAILED,
-  SKIPPED,
+  SUCCESS = 'SUCCESS',
+  FAILED = 'FAILED',
+  SKIPPED = 'SKIPPED',
 }

--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -56,6 +56,7 @@ export class ActRunner<
   TEventType extends WebhookEventName | undefined = undefined,
   TEventPayload extends EventPayload<TEventType> = undefined,
 > {
+  private actExecutable: string | undefined;
   private workingDir: string | undefined;
   private workflowFile: string | undefined;
   private workflowBody: string | undefined;
@@ -74,6 +75,16 @@ export class ActRunner<
   private artifactServer: ActResourceSpec | undefined;
   private additionalArgs: string[] = [];
   private shouldForwardOutput: boolean = false;
+
+  /**
+   * Sets the path to the `act` executable (default: `act` binary on the `PATH`).
+   * Useful in the CI environments, where the executable is provisioned on demand in a controlled location.
+   * @param actExecutable - path to the `act` executable.
+   */
+  withActExecutable(actExecutable: string): this {
+    this.actExecutable = actExecutable;
+    return this;
+  }
 
   /**
    * Sets the directory to use for the runner's storage needs (default: directory in user's temp folder).
@@ -268,7 +279,7 @@ export class ActRunner<
             )
           : new JobTrackingActExecListener();
 
-        const process = spawn('act', params.asCliArgs());
+        const process = spawn(this.actExecutable ?? 'act', params.asCliArgs());
 
         process.stdout.on('data', (data) =>
           executionListener.onStdOutput(data.toString().trimEnd()),
@@ -301,6 +312,10 @@ export class ActRunner<
   }
 
   private validateRunnerParams(): ActRunnerParams<TEventType> {
+    if (this.actExecutable) {
+      checkExists('act executable', this.actExecutable);
+    }
+
     const workingDir = checkExists(
       'working directory',
       firstDefined(() => this.workingDir, createTempDir),

--- a/tests/custom_executable.test.ts
+++ b/tests/custom_executable.test.ts
@@ -42,6 +42,6 @@ test('runs workflow files with the supplied custom executable', async () => {
   );
   const result = await run(customExec);
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   expect(result.output).toContain('Hello from custom act exec');
 });

--- a/tests/custom_executable.test.ts
+++ b/tests/custom_executable.test.ts
@@ -1,0 +1,47 @@
+import { test, expect, beforeEach, afterEach } from 'vitest';
+import { ActExecStatus, ActWorkflowExecResult } from '../src/index.js';
+import { runner, workflowPath } from './fixtures.js';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+
+export async function run(executable: string): Promise<ActWorkflowExecResult> {
+  return runner()
+    .withActExecutable(executable)
+    .withWorkflowFile(workflowPath('always_passing_workflow'))
+    .run();
+}
+
+const customExecDir = join(tmpdir(), 'actTestRunner', 'custom_executable');
+beforeEach(() => {
+  if (!existsSync(customExecDir)) {
+    mkdirSync(customExecDir, { recursive: true });
+  }
+});
+
+afterEach(() => {
+  if (existsSync(customExecDir)) {
+    rmSync(customExecDir, { recursive: true, force: true });
+  }
+});
+
+test('fails if the supplied custom executable does not exist', async () => {
+  await expect(run('non-existing')).rejects.toThrow(
+    "The specified act executable 'non-existing' does not exist",
+  );
+});
+
+test('runs workflow files with the supplied custom executable', async () => {
+  const customExec = join(customExecDir, 'customAct');
+  writeFileSync(
+    customExec,
+    `#!/usr/bin/env bash
+    echo "Hello from custom act exec!"
+  `,
+    { mode: 0o744 },
+  );
+  const result = await run(customExec);
+
+  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result.output).toContain('Hello from custom act exec');
+});

--- a/tests/matchers.ts
+++ b/tests/matchers.ts
@@ -1,0 +1,29 @@
+import { expect } from 'vitest';
+import { ActWorkflowExecResult } from '../src/ActWorkflowExecResult.js';
+import { ActJobExecResult } from '../src/ActJobExecResult.js';
+import { ActExecStatus } from '../src/ActExecStatus.js';
+
+interface CustomMatchers<R = unknown> {
+  toHaveStatus(expected: ActExecStatus): R;
+}
+
+declare module 'vitest' {
+  interface Assertion<T = any> extends CustomMatchers<T> {}
+  interface AsymmetricMatchersContaining extends CustomMatchers {}
+}
+
+expect.extend({
+  toHaveStatus(
+    result: ActWorkflowExecResult | ActJobExecResult,
+    expected: ActExecStatus,
+  ) {
+    const pass = result.status == expected;
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected exec result not to be ${expected}.\nOutput:\n${result.output}`
+          : `expected exec result to be ${expected}, but got ${result.status}.\nOutput:\n${result.output}`,
+    };
+  },
+});

--- a/tests/workflows_artifact_server.test.ts
+++ b/tests/workflows_artifact_server.test.ts
@@ -35,7 +35,7 @@ test('persists workflow artifacts in configured directory', async () => {
     .withEnvValues(['ACTIONS_RUNTIME_TOKEN', 'irrelevant'])
     .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   expect(result.job('store_file_in_artifact_server')!.status).toBe(
     ActExecStatus.SUCCESS,
   );

--- a/tests/workflows_cache.test.ts
+++ b/tests/workflows_cache.test.ts
@@ -27,8 +27,10 @@ test('persists cache entries in configured directory', async () => {
     .withCacheServer(customCacheDir)
     .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
-  expect(result.job('store_file_in_cache')!.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+  expect(result.job('store_file_in_cache')!).toHaveStatus(
+    ActExecStatus.SUCCESS,
+  );
 
   const cacheArtifact = join(customCacheDir, 'cache', '01', '1');
   expect(existsSync(cacheArtifact)).toBe(true);

--- a/tests/workflows_core.test.ts
+++ b/tests/workflows_core.test.ts
@@ -27,24 +27,24 @@ afterEach(() => {
 test('reports successful workflows', async () => {
   const result = await run(workflowPath('always_passing_workflow'));
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   expect(result.output).toContain('Hello, World!');
   expect(result.jobs.size).toBe(1);
 
   const successfulJob = result.job('successful_job')!;
-  expect(successfulJob.status).toBe(ActExecStatus.SUCCESS);
+  expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
   expect(successfulJob.output).toContain('Hello, World!');
 });
 
 test('captures workflow failures', async () => {
   const result = await run(workflowPath('always_failing_workflow'));
 
-  expect(result.status).toBe(ActExecStatus.FAILED);
+  expect(result).toHaveStatus(ActExecStatus.FAILED);
   expect(result.output).toContain('Hello, World!');
   expect(result.jobs.size).toBe(1);
 
   const failingJob = result.job('failing_job')!;
-  expect(failingJob.status).toBe(ActExecStatus.FAILED);
+  expect(failingJob).toHaveStatus(ActExecStatus.FAILED);
   expect(failingJob.output).toContain('Hello, World!');
 });
 
@@ -53,18 +53,18 @@ test('reports all jobs', async () => {
     workflowPath('workflow_with_failing_and_passing_jobs'),
   );
 
-  expect(result.status).toBe(ActExecStatus.FAILED);
+  expect(result).toHaveStatus(ActExecStatus.FAILED);
   expect(result.output).toContain('I succeed!');
   expect(result.output).toContain('I fail!');
   expect(result.jobs.size).toBe(2);
 
   const successfulJob = result.job('successful_job')!;
-  expect(successfulJob.status).toBe(ActExecStatus.SUCCESS);
+  expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
   expect(successfulJob.output).toContain('I succeed!');
   expect(successfulJob.output).not.toContain('I fail!');
 
   const failingJob = result.job('failing_job')!;
-  expect(failingJob.status).toBe(ActExecStatus.FAILED);
+  expect(failingJob).toHaveStatus(ActExecStatus.FAILED);
   expect(failingJob.output).toContain('I fail!');
   expect(failingJob.output).not.toContain('I succeed!');
 });
@@ -86,12 +86,12 @@ jobs:
     )
     .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   expect(result.output).toContain('Hello, World!');
   expect(result.jobs.size).toBe(1);
 
   const successfulJob = result.job('successful_job')!;
-  expect(successfulJob.status).toBe(ActExecStatus.SUCCESS);
+  expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
   expect(successfulJob.output).toContain('Hello, World!');
 });
 
@@ -113,11 +113,11 @@ jobs:
     )
     .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   expect(result.output).toContain('Hello, World!');
   expect(result.jobs.size).toBe(1);
 
   const successfulJob = result.job('successful_job')!;
-  expect(successfulJob.status).toBe(ActExecStatus.SUCCESS);
+  expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
   expect(successfulJob.output).toContain('Hello, World!');
 });

--- a/tests/workflows_env.test.ts
+++ b/tests/workflows_env.test.ts
@@ -13,7 +13,7 @@ test('supports setting environment variable values directly', async () => {
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);
   const job = result.job('print_greeting')!;
-  expect(job.status).toBe(ActExecStatus.SUCCESS);
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hello, Bruce!');
 });
 
@@ -24,6 +24,6 @@ test('supports setting environment variables from file', async () => {
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);
   const job = result.job('print_greeting')!;
-  expect(job.status).toBe(ActExecStatus.SUCCESS);
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Falco!');
 });

--- a/tests/workflows_event.test.ts
+++ b/tests/workflows_event.test.ts
@@ -9,25 +9,25 @@ function eventWorkflowRunner(): ActRunner {
 test('uses the first event type lexicographically from workflow if no event type is set', async () => {
   const result = await eventWorkflowRunner().run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
   const issueJob = result.job('print_issue_title')!;
-  expect(issueJob.status).toBe(ActExecStatus.SUCCESS);
+  expect(issueJob).toHaveStatus(ActExecStatus.SUCCESS);
 
   const prJob = result.job('print_pr_title')!;
-  expect(prJob.status).toBe(ActExecStatus.SKIPPED);
+  expect(prJob).toHaveStatus(ActExecStatus.SKIPPED);
 });
 
 test('allows configuring the event type to trigger the workflow with', async () => {
   const result = await eventWorkflowRunner().withEvent('pull_request').run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
   const issueJob = result.job('print_issue_title')!;
-  expect(issueJob.status).toBe(ActExecStatus.SKIPPED);
+  expect(issueJob).toHaveStatus(ActExecStatus.SKIPPED);
 
   const prJob = result.job('print_pr_title')!;
-  expect(prJob.status).toBe(ActExecStatus.SUCCESS);
+  expect(prJob).toHaveStatus(ActExecStatus.SUCCESS);
 });
 
 test('allows configuring event payload', async () => {
@@ -35,13 +35,13 @@ test('allows configuring event payload', async () => {
     .withEvent('pull_request', eventPayloadPath('pull_request_payload'))
     .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
   const issueJob = result.job('print_issue_title')!;
-  expect(issueJob.status).toBe(ActExecStatus.SKIPPED);
+  expect(issueJob).toHaveStatus(ActExecStatus.SKIPPED);
 
   const prJob = result.job('print_pr_title')!;
-  expect(prJob.status).toBe(ActExecStatus.SUCCESS);
+  expect(prJob).toHaveStatus(ActExecStatus.SUCCESS);
   expect(prJob.output).toContain('PR Title: Example PR payload');
 });
 
@@ -54,12 +54,12 @@ test('allows passing event payload as object', async () => {
     })
     .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
   const issueJob = result.job('print_issue_title')!;
-  expect(issueJob.status).toBe(ActExecStatus.SKIPPED);
+  expect(issueJob).toHaveStatus(ActExecStatus.SKIPPED);
 
   const prJob = result.job('print_pr_title')!;
-  expect(prJob.status).toBe(ActExecStatus.SUCCESS);
+  expect(prJob).toHaveStatus(ActExecStatus.SUCCESS);
   expect(prJob.output).toContain('PR Title: Example PR payload as object');
 });

--- a/tests/workflows_input.test.ts
+++ b/tests/workflows_input.test.ts
@@ -11,9 +11,9 @@ test('supports setting input values directly', async () => {
     .withInputsValues(['greeting', 'Hello'], ['name', 'Bruce'])
     .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   const job = result.job('print_greeting')!;
-  expect(job.status).toBe(ActExecStatus.SUCCESS);
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hello, Bruce!');
 });
 
@@ -22,8 +22,8 @@ test('supports setting input values from file', async () => {
     .withInputsFile(inputPath('greeting.input'))
     .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   const job = result.job('print_greeting')!;
-  expect(job.status).toBe(ActExecStatus.SUCCESS);
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Falco!');
 });

--- a/tests/workflows_matrix.test.ts
+++ b/tests/workflows_matrix.test.ts
@@ -9,7 +9,7 @@ function matrixWorkflowRunner(): ActRunner {
 test('runs workflow with all matrix values by default', async () => {
   const result = await matrixWorkflowRunner().run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
   const matrixJobs = Array.from(result.jobs.values()).filter((job) =>
     job.name.startsWith('print_greeting'),
@@ -32,8 +32,8 @@ test('supports restricting matrix values to run with', async () => {
     .withMatrix(['name', 'Bruce'])
     .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   const job = result.job('print_greeting')!;
-  expect(job.status).toBe(ActExecStatus.SUCCESS);
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Bruce!');
 });

--- a/tests/workflows_secrets.test.ts
+++ b/tests/workflows_secrets.test.ts
@@ -13,9 +13,9 @@ test('supports setting secrets values directly', async () => {
     .withSecretsValues(['GREETING', 'Hello'], ['NAME', 'Bruce'])
     .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   const job = result.job('print_greeting')!;
-  expect(job.status).toBe(ActExecStatus.SUCCESS);
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hello, Bruce!');
 });
 
@@ -24,8 +24,8 @@ test('supports setting secrets values from file', async () => {
     .withSecretsFile(inputPath('greeting.secrets'))
     .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   const job = result.job('print_greeting')!;
-  expect(job.status).toBe(ActExecStatus.SUCCESS);
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Falco!');
 });

--- a/tests/workflows_variables.test.ts
+++ b/tests/workflows_variables.test.ts
@@ -11,9 +11,9 @@ test('supports setting workflow variables directly', async () => {
     .withVariablesValues(['GREETING', 'Hello'], ['NAME', 'Bruce'])
     .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   const job = result.job('print_greeting')!;
-  expect(job.status).toBe(ActExecStatus.SUCCESS);
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hello, Bruce!');
 });
 
@@ -22,8 +22,8 @@ test('supports setting workflow variables from file', async () => {
     .withVariablesFile(inputPath('greeting.variables'))
     .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   const job = result.job('print_greeting')!;
-  expect(job.status).toBe(ActExecStatus.SUCCESS);
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Falco!');
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     exclude: ['**/dist/**', '**/node_modules/**'],
     testTimeout: 50_000,
     globalSetup: './vitest.global.setup.ts',
+    setupFiles: ['./tests/matchers.ts'],
   },
   resolve: {
     // Force Vite to alias any internal imports of 'typescript'


### PR DESCRIPTION
- **feat: support supplying a custom act executable**
- **test: print output on a mis-matching execution status**
- **feat: assign string values to the exec status enum values**
- **docs: document why tests cannot be run in-parallel out of the box**
