### PR TITLE
feat: remove act containers upon workflow failure

### DIFF
--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -38,6 +38,7 @@ import { ActResourceSpec } from './internal/ActResourceSpec.js';
 import { PartialDeep } from './utils/types.js';
 import {
   ActRunnerParams,
+  INTERNAL_ACT_PARAMS,
   MANAGED_ACT_PARAMS,
 } from './internal/ActRunnerParams.js';
 
@@ -283,7 +284,9 @@ export class ActRunner<
             )
           : new JobTrackingActExecListener();
 
-        const process = spawn(this.actExecutable ?? 'act', params.asCliArgs());
+        // apply user arguments + additional internal arguments specific to test execution
+        const args = [...params.asCliArgs(), '--rm'];
+        const process = spawn(this.actExecutable ?? 'act', args);
 
         process.stdout.on('data', (data) =>
           executionListener.onStdOutput(data.toString().trimEnd()),
@@ -350,6 +353,15 @@ export class ActRunner<
     if (overwrittenManagedParams.length > 0) {
       throw new ActRunnerError(
         `The following act arguments must be set via dedicated ActRunner methods, and not via 'withAdditionalArguments': ${overwrittenManagedParams}`,
+      );
+    }
+
+    const overwrittenInternalParams = this.additionalArgs.filter((it) =>
+      INTERNAL_ACT_PARAMS.has(it),
+    );
+    if (overwrittenInternalParams.length > 0) {
+      throw new ActRunnerError(
+        `The following act arguments must not be set via 'withAdditionalArguments', as they are managed by the ActRunner: ${overwrittenInternalParams}`,
       );
     }
 

--- a/src/internal/ActRunnerParams.ts
+++ b/src/internal/ActRunnerParams.ts
@@ -48,6 +48,8 @@ export const MANAGED_ACT_PARAMS: Set<string> = new Set([
   '-e',
 ]);
 
+export const INTERNAL_ACT_PARAMS: Set<string> = new Set(['--rm']);
+
 export class ActRunnerParams<
   EventType extends WebhookEventName | undefined = undefined,
 > {

--- a/tests/config_validation.test.ts
+++ b/tests/config_validation.test.ts
@@ -97,3 +97,14 @@ test('fails if additional arguments contain managed params', async () => {
     "The following act arguments must be set via dedicated ActRunner methods, and not via 'withAdditionalArguments': --detect-event,--input-file",
   );
 });
+
+test('fails if additional arguments contain internal params', async () => {
+  await expect(
+    runner()
+      .withWorkflowFile(workflowPath('always_passing_workflow'))
+      .withAdditionalArgs('--rm')
+      .run(),
+  ).rejects.toThrow(
+    "The following act arguments must not be set via 'withAdditionalArguments', as they are managed by the ActRunner: --rm",
+  );
+});


### PR DESCRIPTION
## Description

By default, `act` keeps the container behind a failed workflow run around. With `act-test-runner` in the picture, this will mean that some test resources will be laying around. This is unexpected and should be avoided. The `--rm` flag does just that. I did not add any functional tests, hoping that `act` does what it claims to do :) 