### PR TITLE
refactor: replace Object with Record<string, string> for matrix type

### DIFF
--- a/src/internal/ActExecListener.ts
+++ b/src/internal/ActExecListener.ts
@@ -39,7 +39,7 @@ type JsonOutput = {
   jobResult?: JobOrStepResult;
   step?: string;
   stepResult?: JobOrStepResult;
-  matrix: Object;
+  matrix: Record<string, string>;
 };
 
 const JOB_LIFECYCLE_STEPS = new Set<string>(['Set up job', 'Complete job']);
@@ -47,13 +47,13 @@ const JOB_LIFECYCLE_STEPS = new Set<string>(['Set up job', 'Complete job']);
 class JobIterationTracker {
   private readonly matrixIdx: Map<string, number> = new Map<string, number>();
 
-  private matrixKey(matrix: Object): string {
+  private matrixKey(matrix: Record<string, string>): string {
     return Object.values(matrix)
       .sort((a, b) => (a > b ? 1 : -1))
       .reduce((prev, curr) => `${prev}_${curr}`);
   }
 
-  iterationIndex(matrix: Object): number {
+  iterationIndex(matrix: Record<string, string>): number {
     const key = this.matrixKey(matrix);
     if (this.matrixIdx.has(key)) {
       return this.matrixIdx.get(key)!;
@@ -182,7 +182,7 @@ export class ActExecListener {
 
   private getJobIterationIdx(
     jobName: string,
-    matrix: Object,
+    matrix: Record<string, string>,
   ): number | undefined {
     if (Object.keys(matrix).length == 0) {
       return undefined;


### PR DESCRIPTION
## Summary
- `JsonOutput.matrix` and the related `JobIterationTracker`/`getJobIterationIdx` signatures in `ActExecListener.ts` used the wrapper type `Object` instead of a precise structural type.
- `act`'s matrix values are always strings, so this uses `Record<string, string>` instead. Internal-only type; no public API change.

Stacked on #179. PR 2 of a stack addressing all findings in #178 (Phase 1, point 2). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`, `utils/*`) — full e2e suite requires `act` + Docker, unavailable in this sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965)_