### PR TITLE
refactor: narrow withMatrix value type from any to string | number | boolean

### DIFF
--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -79,7 +79,10 @@ export class ActRunner<
   private secretsValues: Map<string, string> = new Map<string, string>();
   private variablesFile: string | undefined;
   private variablesValues: Map<string, string> = new Map<string, string>();
-  private matrix: Map<string, any> = new Map<string, any>();
+  private matrix: Map<string, string | number | boolean> = new Map<
+    string,
+    string | number | boolean
+  >();
   private cacheServer: ActResourceSpec | undefined;
   private artifactServer: ActResourceSpec | undefined;
   private additionalArgs: string[] = [];
@@ -218,9 +221,9 @@ export class ActRunner<
   /**
    * Set matrix values to run the workflow with.
    * If undefined, all combinations specified in the workflow definition will be invoked.
-   * @param {...[string, any]} matrixValues - matrix values to run the workflow with
+   * @param {...[string, string | number | boolean]} matrixValues - matrix values to run the workflow with
    */
-  withMatrix(...matrixValues: [string, any][]): this {
+  withMatrix(...matrixValues: [string, string | number | boolean][]): this {
     matrixValues.forEach((entry) => this.matrix.set(entry[0], entry[1]));
     return this;
   }

--- a/src/internal/ActRunnerParams.ts
+++ b/src/internal/ActRunnerParams.ts
@@ -64,7 +64,7 @@ export class ActRunnerParams<
   private readonly secretsValues: Map<string, string>;
   private readonly variablesFile: string | undefined;
   private readonly variablesValues: Map<string, string>;
-  private readonly matrix: Map<string, any>;
+  private readonly matrix: Map<string, string | number | boolean>;
   private readonly cacheServer: ActResourceSpec | undefined;
   private readonly artifactServer: ActResourceSpec | undefined;
   private readonly additionalArgs: string[];
@@ -81,7 +81,7 @@ export class ActRunnerParams<
     secretsValues: Map<string, string>,
     variablesFile: string | undefined,
     variablesValues: Map<string, string>,
-    matrix: Map<string, any>,
+    matrix: Map<string, string | number | boolean>,
     cacheServer: ActResourceSpec | undefined,
     artifactServer: ActResourceSpec | undefined,
     additionalArgs: string[],


### PR DESCRIPTION
## Summary
- `withMatrix(...matrixValues: [string, any][])` allowed any value type, silently permitting non-stringifiable values into what ultimately becomes an `act` CLI flag.
- Narrowed to `string | number | boolean`, the only types a GitHub workflow matrix value can be.

Stacked on #180. PR 3 of a stack addressing all findings in #178 (Phase 1, point 3). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`, `utils/*`) — full e2e suite requires `act` + Docker, unavailable in this sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965)_