### PR TITLE
refactor: make checkOneDefined generic instead of using any

### DIFF
--- a/src/utils/checks.ts
+++ b/src/utils/checks.ts
@@ -22,7 +22,10 @@
 import { ActRunnerError } from '../ActRunnerError.js';
 import { existsSync } from 'node:fs';
 
-export function checkOneDefined(first: any, second: any) {
+export function checkOneDefined<T>(
+  first: T | undefined,
+  second: T | undefined,
+) {
   if (
     (first === undefined && second === undefined) ||
     (first !== undefined && second !== undefined)


### PR DESCRIPTION
## Summary
- `checkOneDefined(first: any, second: any)` lost type safety at every call site.
- Made it generic (`checkOneDefined<T>(first: T | undefined, second: T | undefined)`); all existing call sites pass same-typed pairs so behavior is unchanged.

Stacked on #181. PR 4 of a stack addressing all findings in #178 (Phase 1, point 4). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`, `utils/*`) — full e2e suite requires `act` + Docker, unavailable in this sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965)_