### PR TITLE
refactor: convert ActExecStatus/ActOutputLevel from enum/plain union to const object + union type

### DIFF
--- a/src/ActExecStatus.ts
+++ b/src/ActExecStatus.ts
@@ -22,8 +22,13 @@
 /**
  * Outcome of the workflow or job execution.
  */
-export enum ActExecStatus {
-  SUCCESS = 'SUCCESS',
-  FAILED = 'FAILED',
-  SKIPPED = 'SKIPPED',
-}
+export const ActExecStatus = {
+  SUCCESS: 'SUCCESS',
+  FAILED: 'FAILED',
+  SKIPPED: 'SKIPPED',
+} as const;
+
+/**
+ * Outcome of the workflow or job execution.
+ */
+export type ActExecStatus = (typeof ActExecStatus)[keyof typeof ActExecStatus];

--- a/src/ActOutputListener.ts
+++ b/src/ActOutputListener.ts
@@ -24,7 +24,18 @@ import { formattedMessage } from './internal/outputFormatter.js';
 /**
  * Message's log level.
  */
-export type ActOutputLevel = 'debug' | 'info' | 'warning' | 'error';
+export const ActOutputLevel = {
+  DEBUG: 'debug',
+  INFO: 'info',
+  WARNING: 'warning',
+  ERROR: 'error',
+} as const;
+
+/**
+ * Message's log level.
+ */
+export type ActOutputLevel =
+  (typeof ActOutputLevel)[keyof typeof ActOutputLevel];
 
 /**
  * Single message in the act output stream.

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,4 +25,7 @@ export { ActRunner } from './ActRunner.js';
 export { ActRunnerError } from './ActRunnerError.js';
 export { ActWorkflowExecResult } from './ActWorkflowExecResult.js';
 export type { ActOutputListener, ActOutput } from './ActOutputListener.js';
-export { StdStreamOutputListener } from './ActOutputListener.js';
+export {
+  ActOutputLevel,
+  StdStreamOutputListener,
+} from './ActOutputListener.js';


### PR DESCRIPTION
## Summary
- `ActExecStatus` was a TS `enum` while `ActOutputLevel` modeled the same kind of thing as a plain string union — inconsistent, and `enum` is the more idiosyncratic of the two constructs.
- Converted `ActExecStatus` to a `const` object + derived union type, matching `ActOutputLevel`'s original pattern. `ActExecStatus.SUCCESS`-style value references keep working unchanged, so this is not observable to existing consumers.
- Also converted `ActOutputLevel` itself to the same const-object pattern and exported it as a value from `index.ts` (it wasn't previously exported at all), so consumers can now write `ActOutputLevel.DEBUG` / `.INFO` / `.WARNING` / `.ERROR` instead of hardcoding raw strings — this is additive, not a breaking change.

Stacked on #182. PR 5 of a stack addressing all findings in #178 (Phase 1, point 5 — completes Phase 1). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`, `utils/*`) — full e2e suite requires `act` + Docker, unavailable in this sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965