### PR TITLE
fix: return after reject in run()'s catch block

### DIFF
--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -319,6 +319,7 @@ export class ActRunner<
       } catch (err) {
         if (err instanceof ActRunnerError) {
           reject(err);
+          return;
         }
         reject(
           new ActRunnerError(


### PR DESCRIPTION
## Summary
- `run()`'s catch block called `reject()` twice when the caught error was already an `ActRunnerError` — once with the original error, then unconditionally again with a wrapped "Unexpected error" message.
- Harmless in practice (a promise settles only once) but dead and misleading code. Added the missing `return`.

Stacked on #183. PR 6 of a stack addressing all findings in #178 (Phase 2, point 1). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`) — full e2e suite requires `act` + Docker, unavailable in this sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965)_