### PR TITLE
refactor: rename spawned child_process variable from process to child

### DIFF
--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -297,16 +297,16 @@ export class ActRunner<
 
         // apply user arguments + additional internal arguments specific to test execution
         const args = [...params.asCliArgs(), '--rm', '--json'];
-        const process = spawn(this.actExecutable ?? 'act', args);
+        const child = spawn(this.actExecutable ?? 'act', args);
 
-        process.stdout.on('data', (data) =>
+        child.stdout.on('data', (data) =>
           executionListener.onRawOutput(data.toString().trimEnd()),
         );
-        process.stderr.on('data', (data) =>
+        child.stderr.on('data', (data) =>
           executionListener.onRawOutput(data.toString().trimEnd()),
         );
 
-        process.on('close', (code) => {
+        child.on('close', (code) => {
           cleanupDir(this.workingDir!);
           resolve(
             new ActWorkflowExecResult(


### PR DESCRIPTION
## Summary
- `const process = spawn(...)` in `run()` shadowed the Node global `process`. Worked today only because nothing in that closure needed the real `process` object, but it's a footgun for the next change made in this method.
- Renamed to `child` and updated the three references below it.

Stacked on #184. PR 7 of a stack addressing all findings in #178 (Phase 2, point 2). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`) — full e2e suite requires `act` + Docker, unavailable in this sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965)_