### PR TITLE
fix: reject clearly when the act process fails to launch

### DIFF
--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -316,6 +316,10 @@ export class ActRunner<
             ),
           );
         });
+
+        child.on('error', (err) => {
+          reject(new ActRunnerError(`Failed to launch act: ${err.message}`));
+        });
       } catch (err) {
         if (err instanceof ActRunnerError) {
           reject(err);

--- a/tests/custom_executable.test.ts
+++ b/tests/custom_executable.test.ts
@@ -31,6 +31,11 @@ test('fails if the supplied custom executable does not exist', async () => {
   );
 });
 
+test('rejects with a clear error if the supplied executable cannot be launched', async () => {
+  // a directory exists on disk but can never be spawned as a process
+  await expect(run(customExecDir)).rejects.toThrow(/Failed to launch act/);
+});
+
 test('runs workflow files with the supplied custom executable', async () => {
   const customExec = join(customExecDir, 'customAct');
   writeFileSync(


### PR DESCRIPTION
## Summary
- `checkExists('act executable', ...)` only ran when `withActExecutable` was explicitly set; the default case (`spawn('act', args)`, `act` not on `PATH`) had no pre-check.
- If `spawn` couldn't launch the process, it emitted `'error'`, which nothing listened for — `run()`'s promise never settled instead of rejecting with a clear `ActRunnerError`.
- Added a `child.on('error', ...)` handler that rejects with a descriptive `ActRunnerError`, plus a regression test (`custom_executable.test.ts`) that points the executable at a directory — a path that passes the existence check but can never be spawned, deterministically triggering the `error` event without depending on `act` being absent from `PATH`.

Stacked on #185. PR 8 of a stack addressing all findings in #178 (Phase 2, point 3). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`, including the new regression test) — full e2e suite requires `act` + Docker, unavailable in this sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965)_