### PR TITLE
fix: guard against reusing an ActRunner instance across multiple run() calls

### DIFF
--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -60,6 +60,8 @@ type EventPayload<TEventType extends WebhookEventName | undefined = undefined> =
  * Assertions can then be made on the outcome of the `run()` method invocation, such as the jobs run, workflow output, or artifacts persisted in the artifact server or action cache.
  *
  * The runner cannot be used concurrently due to limitations on the `act` side.
+ *
+ * Each instance is single-use: calling `run()` more than once on the same instance rejects with an `ActRunnerError`. Create a new instance for each run.
  */
 export class ActRunner<
   TEventType extends WebhookEventName | undefined = undefined,
@@ -87,6 +89,7 @@ export class ActRunner<
   private artifactServer: ActResourceSpec | undefined;
   private additionalArgs: string[] = [];
   private outputListener: ActOutputListener | undefined;
+  private hasRun: boolean = false;
 
   /**
    * Sets the path to the `act` executable (default: `act` binary on the `PATH`).
@@ -291,6 +294,13 @@ export class ActRunner<
   run(): Promise<ActWorkflowExecResult> {
     return new Promise<ActWorkflowExecResult>((resolve, reject) => {
       try {
+        if (this.hasRun) {
+          throw new ActRunnerError(
+            'ActRunner instances cannot be reused; create a new instance for each run()',
+          );
+        }
+        this.hasRun = true;
+
         const params = this.validateRunnerParams();
 
         const executionListener = new ActExecListener(this.outputListener);

--- a/tests/custom_executable.test.ts
+++ b/tests/custom_executable.test.ts
@@ -50,3 +50,23 @@ test('runs workflow files with the supplied custom executable', async () => {
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   expect(result.output).toContain('Hello from custom act exec');
 });
+
+test('rejects if run() is called more than once on the same instance', async () => {
+  const customExec = join(customExecDir, 'customAct');
+  writeFileSync(
+    customExec,
+    `#!/usr/bin/env bash
+    echo "Hello from custom act exec!"
+  `,
+    { mode: 0o744 },
+  );
+  const testRunner = runner()
+    .withActExecutable(customExec)
+    .withWorkflowFile(workflowPath('always_passing_workflow'));
+
+  await testRunner.run();
+
+  await expect(testRunner.run()).rejects.toThrow(
+    'ActRunner instances cannot be reused; create a new instance for each run()',
+  );
+});


### PR DESCRIPTION
## Summary
- `ActRunner` instances were implicitly single-use, undocumented, and unenforced. `run()` deletes the working directory on completion (`cleanupDir`) and mutates instance fields in place, so calling `.run()` a second time on the same instance (e.g. for a `withWorkflowBody` runner) would fail with a confusing `ENOENT` rather than a clear error.
- Added a `hasRun` guard that throws a descriptive `ActRunnerError` on a second `run()` call, documented the single-use contract on the class docstring, and added a regression test asserting the second call rejects.

Stacked on #186. PR 9 of a stack addressing all findings in #178 (Phase 2, point 4 — completes Phase 2). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`, including the new regression test) — full e2e suite requires `act` + Docker, unavailable in this sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965)_