### PR TITLE
feat!: replace varargs-of-tuples with Record objects for value maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ jobs:
         run: echo "$GREETING, $NAME!"
   `,
     )
-    .withEnvValues(['GREETING', 'Hello'], ['NAME', 'Bruce'])
+    .withEnvValues({ GREETING: 'Hello', NAME: 'Bruce' })
     .run();
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pshevche/act-test-runner",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Convention wrapper around https://github.com/nektos/act for e2e testing GitHub actions",
   "author": "Pavlo Shevchenko",
   "keywords": [

--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -156,10 +156,12 @@ export class ActRunner<
 
   /**
    * Sets environment variables to use when invoking the given workflow.
-   * @param {...[string, string]} envValues - environment variable values to use as env in the containers
+   * @param envValues - environment variable values to use as env in the containers
    */
-  withEnvValues(...envValues: [string, string][]): this {
-    envValues.forEach((entry) => this.envValues.set(entry[0], entry[1]));
+  withEnvValues(envValues: Record<string, string>): this {
+    Object.entries(envValues).forEach(([key, value]) =>
+      this.envValues.set(key, value),
+    );
     return this;
   }
 
@@ -174,10 +176,12 @@ export class ActRunner<
 
   /**
    * Sets inputs values to use when invoking the given workflow.
-   * @param {...[string, string]} inputsValues - action input to make available to actions
+   * @param inputsValues - action input to make available to actions
    */
-  withInputsValues(...inputsValues: [string, string][]): this {
-    inputsValues.forEach((entry) => this.inputsValues.set(entry[0], entry[1]));
+  withInputsValues(inputsValues: Record<string, string>): this {
+    Object.entries(inputsValues).forEach(([key, value]) =>
+      this.inputsValues.set(key, value),
+    );
     return this;
   }
 
@@ -192,11 +196,11 @@ export class ActRunner<
 
   /**
    * Sets secrets values to use when invoking the given workflow.
-   * @param {...[string, string]} secretsValues - secrets to make available to actions
+   * @param secretsValues - secrets to make available to actions
    */
-  withSecretsValues(...secretsValues: [string, string][]): this {
-    secretsValues.forEach((entry) =>
-      this.secretsValues.set(entry[0], entry[1]),
+  withSecretsValues(secretsValues: Record<string, string>): this {
+    Object.entries(secretsValues).forEach(([key, value]) =>
+      this.secretsValues.set(key, value),
     );
     return this;
   }
@@ -212,11 +216,11 @@ export class ActRunner<
 
   /**
    * Sets variables values to use when invoking the given workflow.
-   * @param {...[string, string]} variablesValues - secrets to make available to actions
+   * @param variablesValues - secrets to make available to actions
    */
-  withVariablesValues(...variablesValues: [string, string][]): this {
-    variablesValues.forEach((entry) =>
-      this.variablesValues.set(entry[0], entry[1]),
+  withVariablesValues(variablesValues: Record<string, string>): this {
+    Object.entries(variablesValues).forEach(([key, value]) =>
+      this.variablesValues.set(key, value),
     );
     return this;
   }
@@ -224,10 +228,12 @@ export class ActRunner<
   /**
    * Set matrix values to run the workflow with.
    * If undefined, all combinations specified in the workflow definition will be invoked.
-   * @param {...[string, string | number | boolean]} matrixValues - matrix values to run the workflow with
+   * @param matrixValues - matrix values to run the workflow with
    */
-  withMatrix(...matrixValues: [string, string | number | boolean][]): this {
-    matrixValues.forEach((entry) => this.matrix.set(entry[0], entry[1]));
+  withMatrix(matrixValues: Record<string, string | number | boolean>): this {
+    Object.entries(matrixValues).forEach(([key, value]) =>
+      this.matrix.set(key, value),
+    );
     return this;
   }
 

--- a/tests/workflows_artifact_server.test.ts
+++ b/tests/workflows_artifact_server.test.ts
@@ -32,7 +32,7 @@ test('persists workflow artifacts in configured directory', async () => {
   const result = await artifactServerWorkflowRunner()
     .withArtifactServer(artifactServerDir)
     // required to execute upload-artifact action
-    .withEnvValues(['ACTIONS_RUNTIME_TOKEN', 'irrelevant'])
+    .withEnvValues({ ACTIONS_RUNTIME_TOKEN: 'irrelevant' })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);

--- a/tests/workflows_env.test.ts
+++ b/tests/workflows_env.test.ts
@@ -8,7 +8,7 @@ function envWorkflowRunner(): ActRunner {
 
 test('supports setting environment variable values directly', async () => {
   const result = await envWorkflowRunner()
-    .withEnvValues(['GREETING', 'Hello'], ['NAME', 'Bruce'])
+    .withEnvValues({ GREETING: 'Hello', NAME: 'Bruce' })
     .run();
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);

--- a/tests/workflows_input.test.ts
+++ b/tests/workflows_input.test.ts
@@ -8,7 +8,7 @@ function inputWorkflowRunner(): ActRunner {
 
 test('supports setting input values directly', async () => {
   const result = await inputWorkflowRunner()
-    .withInputsValues(['greeting', 'Hello'], ['name', 'Bruce'])
+    .withInputsValues({ greeting: 'Hello', name: 'Bruce' })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);

--- a/tests/workflows_matrix.test.ts
+++ b/tests/workflows_matrix.test.ts
@@ -33,8 +33,7 @@ test('runs workflow with all matrix values by default', async () => {
 
 test('supports restricting matrix values to run with', async () => {
   const result = await matrixWorkflowRunner()
-    .withMatrix(['greeting', 'Hallo'])
-    .withMatrix(['name', 'Bruce'])
+    .withMatrix({ greeting: 'Hallo', name: 'Bruce' })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);

--- a/tests/workflows_secrets.test.ts
+++ b/tests/workflows_secrets.test.ts
@@ -10,7 +10,7 @@ function secretsWorkflowRunner(): ActRunner {
 
 test('supports setting secrets values directly', async () => {
   const result = await secretsWorkflowRunner()
-    .withSecretsValues(['GREETING', 'Hello'], ['NAME', 'Bruce'])
+    .withSecretsValues({ GREETING: 'Hello', NAME: 'Bruce' })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);

--- a/tests/workflows_variables.test.ts
+++ b/tests/workflows_variables.test.ts
@@ -8,7 +8,7 @@ function variablesWorkflowRunner(): ActRunner {
 
 test('supports setting workflow variables directly', async () => {
   const result = await variablesWorkflowRunner()
-    .withVariablesValues(['GREETING', 'Hello'], ['NAME', 'Bruce'])
+    .withVariablesValues({ GREETING: 'Hello', NAME: 'Bruce' })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);


### PR DESCRIPTION
## Summary
- **BREAKING CHANGE.** `withEnvValues`, `withInputsValues`, `withSecretsValues`, `withVariablesValues` (`...values: [string, string][]`) and `withMatrix` (`...matrixValues: [string, string | number | boolean][]`) used a varargs-of-tuples shape, an unusual and error-prone way to model a plain key/value map in TypeScript.
- They now take a single `Record<string, V>` object instead:
  ```js
  // before
  .withEnvValues(['GREETING', 'Hello'], ['NAME', 'Bruce'])
  // after
  .withEnvValues({ GREETING: 'Hello', NAME: 'Bruce' })
  ```
- Updated all call sites in tests and the README example in the same commit.
- Bumped `package.json` version to `2.0.0` — this is the first breaking change in the stack, per the major-version-bump plan in #178.

Stacked on #187. PR 10 of a stack addressing all findings in #178 (Phase 3, point 1 — starts the breaking-change phase). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`, `utils/*`) — full e2e suite requires `act` + Docker, unavailable in this sandbox; updated e2e test call sites are verified via `types:check` passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965)_