### PR TITLE
feat!: merge file/values method pairs into single options-object methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ jobs:
         run: echo "$GREETING, $NAME!"
   `,
     )
-    .withEnvValues({ GREETING: 'Hello', NAME: 'Bruce' })
+    .withEnv({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
     .run();
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);

--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -53,6 +53,20 @@ type EventPayload<TEventType extends WebhookEventName | undefined = undefined> =
   | undefined;
 
 /**
+ * Source of key/value pairs (environment variables, inputs, secrets, or variables), provided via a file, inline values, or both.
+ */
+export type ActValueSource = {
+  /**
+   * Path to a file containing the values.
+   */
+  file?: string;
+  /**
+   * Inline values.
+   */
+  values?: Record<string, string>;
+};
+
+/**
  * Invokes `act`, allowing end-to-end testing of custom GitHub actions and workflows.
  *
  * Typically, the test code will provide a workflow file or workflow body to run, as well as required workflow inputs, such as environment variables or secrets.
@@ -146,83 +160,52 @@ export class ActRunner<
   }
 
   /**
-   * Specifies the file containing environment variables to use when invoking the given workflow.
-   * @param {string} envFile - file containing environment variables values to use as env in the containers
+   * Specifies environment variables to use when invoking the given workflow, provided via a file, inline values, or both.
+   * @param source - environment variables source
    */
-  withEnvFile(envFile: string): this {
-    this.envFile = envFile;
+  withEnv(source: ActValueSource): this {
+    this.envFile = source.file;
+    this.setValues(this.envValues, source.values);
     return this;
   }
 
   /**
-   * Sets environment variables to use when invoking the given workflow.
-   * @param envValues - environment variable values to use as env in the containers
+   * Specifies inputs values to use when invoking the given workflow, provided via a file, inline values, or both.
+   * @param source - inputs values source
    */
-  withEnvValues(envValues: Record<string, string>): this {
-    Object.entries(envValues).forEach(([key, value]) =>
-      this.envValues.set(key, value),
-    );
+  withInputs(source: ActValueSource): this {
+    this.inputsFile = source.file;
+    this.setValues(this.inputsValues, source.values);
     return this;
   }
 
   /**
-   * Specifies the file containing inputs values to use when invoking the given workflow.
-   * @param {string} inputsFile - input file to read and use as action input
+   * Specifies secrets values to use when invoking the given workflow, provided via a file, inline values, or both.
+   * @param source - secrets values source
    */
-  withInputsFile(inputsFile: string): this {
-    this.inputsFile = inputsFile;
+  withSecrets(source: ActValueSource): this {
+    this.secretsFile = source.file;
+    this.setValues(this.secretsValues, source.values);
     return this;
   }
 
   /**
-   * Sets inputs values to use when invoking the given workflow.
-   * @param inputsValues - action input to make available to actions
+   * Specifies workflow variables values to use when invoking the given workflow, provided via a file, inline values, or both.
+   * @param source - variables values source
    */
-  withInputsValues(inputsValues: Record<string, string>): this {
-    Object.entries(inputsValues).forEach(([key, value]) =>
-      this.inputsValues.set(key, value),
-    );
+  withVariables(source: ActValueSource): this {
+    this.variablesFile = source.file;
+    this.setValues(this.variablesValues, source.values);
     return this;
   }
 
-  /**
-   * Specifies the file containing secrets values to use when invoking the given workflow.
-   * @param {string} secretsFile - secrets file to read and use as action input
-   */
-  withSecretsFile(secretsFile: string): this {
-    this.secretsFile = secretsFile;
-    return this;
-  }
-
-  /**
-   * Sets secrets values to use when invoking the given workflow.
-   * @param secretsValues - secrets to make available to actions
-   */
-  withSecretsValues(secretsValues: Record<string, string>): this {
-    Object.entries(secretsValues).forEach(([key, value]) =>
-      this.secretsValues.set(key, value),
-    );
-    return this;
-  }
-
-  /**
-   * Specifies the file containing workflow variables values to use when invoking the given workflow.
-   * @param {string} variablesFile - variables file to read and use as action input
-   */
-  withVariablesFile(variablesFile: string): this {
-    this.variablesFile = variablesFile;
-    return this;
-  }
-
-  /**
-   * Sets variables values to use when invoking the given workflow.
-   * @param variablesValues - secrets to make available to actions
-   */
-  withVariablesValues(variablesValues: Record<string, string>): this {
-    Object.entries(variablesValues).forEach(([key, value]) =>
-      this.variablesValues.set(key, value),
-    );
-    return this;
+  private setValues(
+    target: Map<string, string>,
+    values: Record<string, string> | undefined,
+  ): void {
+    if (values !== undefined) {
+      Object.entries(values).forEach(([key, value]) => target.set(key, value));
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@
 export { ActExecStatus } from './ActExecStatus.js';
 export { ActJobExecResult } from './ActJobExecResult.js';
 export { ActRunner } from './ActRunner.js';
+export type { ActValueSource } from './ActRunner.js';
 export { ActRunnerError } from './ActRunnerError.js';
 export { ActWorkflowExecResult } from './ActWorkflowExecResult.js';
 export type { ActOutputListener, ActOutput } from './ActOutputListener.js';

--- a/tests/config_validation.test.ts
+++ b/tests/config_validation.test.ts
@@ -31,7 +31,7 @@ test('fails if provided env file does not exist', async () => {
   await expect(
     runner()
       .withWorkflowFile(workflowPath('always_passing_workflow'))
-      .withEnvFile('non-existing')
+      .withEnv({ file: 'non-existing' })
       .run(),
   ).rejects.toThrow(
     "The specified env values file 'non-existing' does not exist",
@@ -42,7 +42,7 @@ test('fails if provided input values file does not exist', async () => {
   await expect(
     runner()
       .withWorkflowFile(workflowPath('always_passing_workflow'))
-      .withInputsFile('non-existing')
+      .withInputs({ file: 'non-existing' })
       .run(),
   ).rejects.toThrow(
     "The specified input values file 'non-existing' does not exist",
@@ -64,7 +64,7 @@ test('fails if provided secrets values file does not exist', async () => {
   await expect(
     runner()
       .withWorkflowFile(workflowPath('always_passing_workflow'))
-      .withSecretsFile('non-existing')
+      .withSecrets({ file: 'non-existing' })
       .run(),
   ).rejects.toThrow(
     "The specified secrets values file 'non-existing' does not exist",
@@ -75,7 +75,7 @@ test('fails if provided variables values file does not exist', async () => {
   await expect(
     runner()
       .withWorkflowFile(workflowPath('always_passing_workflow'))
-      .withVariablesFile('non-existing')
+      .withVariables({ file: 'non-existing' })
       .run(),
   ).rejects.toThrow(
     "The specified variables values file 'non-existing' does not exist",

--- a/tests/workflows_artifact_server.test.ts
+++ b/tests/workflows_artifact_server.test.ts
@@ -32,7 +32,7 @@ test('persists workflow artifacts in configured directory', async () => {
   const result = await artifactServerWorkflowRunner()
     .withArtifactServer(artifactServerDir)
     // required to execute upload-artifact action
-    .withEnvValues({ ACTIONS_RUNTIME_TOKEN: 'irrelevant' })
+    .withEnv({ values: { ACTIONS_RUNTIME_TOKEN: 'irrelevant' } })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);

--- a/tests/workflows_env.test.ts
+++ b/tests/workflows_env.test.ts
@@ -27,3 +27,16 @@ test('supports setting environment variables from file', async () => {
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Falco!');
 });
+
+test('supports combining a values file with inline overrides', async () => {
+  // greeting.env sets GREETING=Hallo, NAME=Falco; NAME is overridden inline
+  // while GREETING is left to come from the file, proving both sources apply
+  const result = await envWorkflowRunner()
+    .withEnv({ file: inputPath('greeting.env'), values: { NAME: 'Bruce' } })
+    .run();
+
+  expect(result.status).toBe(ActExecStatus.SUCCESS);
+  const job = result.job('print_greeting')!;
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+  expect(job.output).toContain('Hallo, Bruce!');
+});

--- a/tests/workflows_env.test.ts
+++ b/tests/workflows_env.test.ts
@@ -8,7 +8,7 @@ function envWorkflowRunner(): ActRunner {
 
 test('supports setting environment variable values directly', async () => {
   const result = await envWorkflowRunner()
-    .withEnvValues({ GREETING: 'Hello', NAME: 'Bruce' })
+    .withEnv({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
     .run();
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);
@@ -19,7 +19,7 @@ test('supports setting environment variable values directly', async () => {
 
 test('supports setting environment variables from file', async () => {
   const result = await envWorkflowRunner()
-    .withEnvFile(inputPath('greeting.env'))
+    .withEnv({ file: inputPath('greeting.env') })
     .run();
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);

--- a/tests/workflows_input.test.ts
+++ b/tests/workflows_input.test.ts
@@ -8,7 +8,7 @@ function inputWorkflowRunner(): ActRunner {
 
 test('supports setting input values directly', async () => {
   const result = await inputWorkflowRunner()
-    .withInputsValues({ greeting: 'Hello', name: 'Bruce' })
+    .withInputs({ values: { greeting: 'Hello', name: 'Bruce' } })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
@@ -19,7 +19,7 @@ test('supports setting input values directly', async () => {
 
 test('supports setting input values from file', async () => {
   const result = await inputWorkflowRunner()
-    .withInputsFile(inputPath('greeting.input'))
+    .withInputs({ file: inputPath('greeting.input') })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);

--- a/tests/workflows_input.test.ts
+++ b/tests/workflows_input.test.ts
@@ -27,3 +27,19 @@ test('supports setting input values from file', async () => {
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Falco!');
 });
+
+test('supports combining a values file with inline overrides', async () => {
+  // greeting.input sets greeting=Hallo, name=Falco; name is overridden inline
+  // while greeting is left to come from the file, proving both sources apply
+  const result = await inputWorkflowRunner()
+    .withInputs({
+      file: inputPath('greeting.input'),
+      values: { name: 'Bruce' },
+    })
+    .run();
+
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+  const job = result.job('print_greeting')!;
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+  expect(job.output).toContain('Hallo, Bruce!');
+});

--- a/tests/workflows_secrets.test.ts
+++ b/tests/workflows_secrets.test.ts
@@ -10,7 +10,7 @@ function secretsWorkflowRunner(): ActRunner {
 
 test('supports setting secrets values directly', async () => {
   const result = await secretsWorkflowRunner()
-    .withSecretsValues({ GREETING: 'Hello', NAME: 'Bruce' })
+    .withSecrets({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
@@ -21,7 +21,7 @@ test('supports setting secrets values directly', async () => {
 
 test('supports setting secrets values from file', async () => {
   const result = await secretsWorkflowRunner()
-    .withSecretsFile(inputPath('greeting.secrets'))
+    .withSecrets({ file: inputPath('greeting.secrets') })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);

--- a/tests/workflows_secrets.test.ts
+++ b/tests/workflows_secrets.test.ts
@@ -29,3 +29,20 @@ test('supports setting secrets values from file', async () => {
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Falco!');
 });
+
+test('supports combining a values file with inline overrides', async () => {
+  // greeting.secrets sets GREETING=Hallo, NAME=Falco; NAME is overridden
+  // inline while GREETING is left to come from the file, proving both
+  // sources apply
+  const result = await secretsWorkflowRunner()
+    .withSecrets({
+      file: inputPath('greeting.secrets'),
+      values: { NAME: 'Bruce' },
+    })
+    .run();
+
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+  const job = result.job('print_greeting')!;
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+  expect(job.output).toContain('Hallo, Bruce!');
+});

--- a/tests/workflows_variables.test.ts
+++ b/tests/workflows_variables.test.ts
@@ -27,3 +27,20 @@ test('supports setting workflow variables from file', async () => {
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Falco!');
 });
+
+test('supports combining a values file with inline overrides', async () => {
+  // greeting.variables sets GREETING=Hallo, NAME=Falco; NAME is overridden
+  // inline while GREETING is left to come from the file, proving both
+  // sources apply
+  const result = await variablesWorkflowRunner()
+    .withVariables({
+      file: inputPath('greeting.variables'),
+      values: { NAME: 'Bruce' },
+    })
+    .run();
+
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+  const job = result.job('print_greeting')!;
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+  expect(job.output).toContain('Hallo, Bruce!');
+});

--- a/tests/workflows_variables.test.ts
+++ b/tests/workflows_variables.test.ts
@@ -8,7 +8,7 @@ function variablesWorkflowRunner(): ActRunner {
 
 test('supports setting workflow variables directly', async () => {
   const result = await variablesWorkflowRunner()
-    .withVariablesValues({ GREETING: 'Hello', NAME: 'Bruce' })
+    .withVariables({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
@@ -19,7 +19,7 @@ test('supports setting workflow variables directly', async () => {
 
 test('supports setting workflow variables from file', async () => {
   const result = await variablesWorkflowRunner()
-    .withVariablesFile(inputPath('greeting.variables'))
+    .withVariables({ file: inputPath('greeting.variables') })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);


### PR DESCRIPTION
## Summary
- **BREAKING CHANGE.** `withEnvFile`/`withEnvValues`, `withInputsFile`/`withInputsValues`, `withSecretsFile`/`withSecretsValues`, and `withVariablesFile`/`withVariablesValues` modeled the same "one concern, provided via file or inline values" choice as 8 separate methods, but file and values aren't mutually exclusive (`act` supports combining both, and `ActRunnerParams.addInputs` already handles both independently), so the split was pure surface area.
- Merged each pair into a single method taking an `ActValueSource` options object:
  ```js
  // before
  .withEnvFile(path)
  .withEnvValues({ GREETING: 'Hello' })
  // after
  .withEnv({ file: path })
  .withEnv({ values: { GREETING: 'Hello' } })
  // or both at once
  .withEnv({ file: path, values: { GREETING: 'Hello' } })
  ```
- `ActValueSource` is exported since it's now part of the public method signatures.
- Updated all call sites in tests and the README example.

Stacked on #188. PR 11 of a stack addressing all findings in #178 (Phase 3, point 2). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`, `utils/*`) — full e2e suite requires `act` + Docker, unavailable in this sandbox; updated e2e test call sites are verified via `types:check` passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965)_