### PR TITLE
feat!: merge withWorkflowFile/withWorkflowBody into withWorkflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ To try it out yourself, check out the [act-test-runner-example](https://github.c
 ```JavaScript
 test('custom workflow', async () => {
   const result = await new ActRunner()
-    .withWorkflowBody(
-      `
+    .withWorkflow({
+      body: `
 name: Simple passing workflow
 on: [push]
 
@@ -33,7 +33,7 @@ jobs:
       - name: Successful step
         run: echo "Hello, World!"
   `,
-    )
+    })
     .run();
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);
@@ -51,8 +51,8 @@ jobs:
 ```JavaScript
 test('custom workflow with event', async () => {
   const result = await new ActRunner()
-    .withWorkflowBody(
-      `
+    .withWorkflow({
+      body: `
 name: Workflow printing the PR title
 on:
   pull_request:
@@ -67,7 +67,7 @@ jobs:
         run: |
           echo "PR Title: ${{ github.event.pull_request.title }}"
   `,
-    )
+    })
     .withEvent('pull_request', {
       pull_request: {
         title: 'Example PR payload as object',
@@ -87,8 +87,8 @@ jobs:
 ```JavaScript
 test('custom workflow with inputs', async () => {
   const result = await new ActRunner()
-    .withWorkflowBody(
-      `
+    .withWorkflow({
+      body: `
 name: Simple workflow printing a couple of environment variables
 on: [push]
 
@@ -99,7 +99,7 @@ jobs:
       - name: Print greeting from env variables
         run: echo "$GREETING, $NAME!"
   `,
-    )
+    })
     .withEnv({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
     .run();
 

--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -34,7 +34,11 @@ import {
 import { firstDefined } from './utils/objects.js';
 import { checkExists, checkOneDefined } from './utils/checks.js';
 import { PartialDeep } from './utils/types.js';
-import type { ActResourceServerSpec } from './ActResourceServerSpec.js';
+import type {
+  ActValueSource,
+  ActWorkflowSource,
+  ActResourceServerSpec,
+} from './ActRunnerOptions.js';
 import {
   ActRunnerParams,
   INTERNAL_ACT_PARAMS,
@@ -51,27 +55,6 @@ type EventPayload<TEventType extends WebhookEventName | undefined = undefined> =
       ? PartialDeep<WebhookEventMap[TEventType]> | string
       : string)
   | undefined;
-
-/**
- * Source of key/value pairs (environment variables, inputs, secrets, or variables), provided via a file, inline values, or both.
- */
-export type ActValueSource = {
-  /**
-   * Path to a file containing the values.
-   */
-  file?: string;
-  /**
-   * Inline values.
-   */
-  values?: Record<string, string>;
-};
-
-export type { ActResourceServerSpec };
-
-/**
- * Source of the GitHub workflow to run, provided either as a file path or inline body.
- */
-export type ActWorkflowSource = { file: string } | { body: string };
 
 /**
  * Invokes `act`, allowing end-to-end testing of custom GitHub actions and workflows.

--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -69,6 +69,11 @@ export type ActValueSource = {
 export type { ActResourceServerSpec };
 
 /**
+ * Source of the GitHub workflow to run, provided either as a file path or inline body.
+ */
+export type ActWorkflowSource = { file: string } | { body: string };
+
+/**
  * Invokes `act`, allowing end-to-end testing of custom GitHub actions and workflows.
  *
  * Typically, the test code will provide a workflow file or workflow body to run, as well as required workflow inputs, such as environment variables or secrets.
@@ -85,8 +90,7 @@ export class ActRunner<
 > {
   private actExecutable: string | undefined;
   private workingDir: string | undefined;
-  private workflowFile: string | undefined;
-  private workflowBody: string | undefined;
+  private workflowSource: ActWorkflowSource | undefined;
   private eventType: TEventType | undefined;
   private eventPayloadFileOrBody: TEventPayload | undefined;
   private envFile: string | undefined;
@@ -127,22 +131,11 @@ export class ActRunner<
   }
 
   /**
-   * Specifies the GitHub workflow file to run.
-   * Only one of `workflowPath` and `workflowBody` can be set.
-   * @param {string} workflowsPath - path to the workflow file to run
+   * Specifies the GitHub workflow to run, either as a file path or an inline body.
+   * @param source - the workflow source
    */
-  withWorkflowFile(workflowsPath: string): this {
-    this.workflowFile = workflowsPath;
-    return this;
-  }
-
-  /**
-   * Specifies the content of the GitHub workflow to run.
-   * Only one of `workflowPath` and `workflowBody` can be set.
-   * @param {string} workflowBody - body of the workflow to run
-   */
-  withWorkflowBody(workflowBody: string): this {
-    this.workflowBody = workflowBody;
+  withWorkflow(source: ActWorkflowSource): this {
+    this.workflowSource = source;
     return this;
   }
 
@@ -335,12 +328,21 @@ export class ActRunner<
 
     this.workingDir = workingDir;
 
-    checkOneDefined(this.workflowFile, this.workflowBody);
+    const workflowFile =
+      this.workflowSource && 'file' in this.workflowSource
+        ? this.workflowSource.file
+        : undefined;
+    const workflowBody =
+      this.workflowSource && 'body' in this.workflowSource
+        ? this.workflowSource.body
+        : undefined;
+
+    checkOneDefined(workflowFile, workflowBody);
     const workflowFilePath = checkExists(
       'workflow path',
-      this.workflowFile ||
-        (this.workflowBody !== undefined
-          ? createTempWorkflowFile(workingDir, this.workflowBody)
+      workflowFile ||
+        (workflowBody !== undefined
+          ? createTempWorkflowFile(workingDir, workflowBody)
           : undefined),
     );
 

--- a/src/ActRunnerOptions.ts
+++ b/src/ActRunnerOptions.ts
@@ -20,6 +20,25 @@
  */
 
 /**
+ * Source of key/value pairs (environment variables, inputs, secrets, or variables), provided via a file, inline values, or both.
+ */
+export type ActValueSource = {
+  /**
+   * Path to a file containing the values.
+   */
+  file?: string;
+  /**
+   * Inline values.
+   */
+  values?: Record<string, string>;
+};
+
+/**
+ * Source of the GitHub workflow to run, provided either as a file path or inline body.
+ */
+export type ActWorkflowSource = { file: string } | { body: string };
+
+/**
  * Configuration for the cache or artifact server used by a workflow run.
  */
 export type ActResourceServerSpec = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,9 +24,9 @@ export { ActJobExecResult } from './ActJobExecResult.js';
 export { ActRunner } from './ActRunner.js';
 export type {
   ActValueSource,
-  ActResourceServerSpec,
   ActWorkflowSource,
-} from './ActRunner.js';
+  ActResourceServerSpec,
+} from './ActRunnerOptions.js';
 export { ActRunnerError } from './ActRunnerError.js';
 export { ActWorkflowExecResult } from './ActWorkflowExecResult.js';
 export type { ActOutputListener, ActOutput } from './ActOutputListener.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,11 @@
 export { ActExecStatus } from './ActExecStatus.js';
 export { ActJobExecResult } from './ActJobExecResult.js';
 export { ActRunner } from './ActRunner.js';
-export type { ActValueSource, ActResourceServerSpec } from './ActRunner.js';
+export type {
+  ActValueSource,
+  ActResourceServerSpec,
+  ActWorkflowSource,
+} from './ActRunner.js';
 export { ActRunnerError } from './ActRunnerError.js';
 export { ActWorkflowExecResult } from './ActWorkflowExecResult.js';
 export type { ActOutputListener, ActOutput } from './ActOutputListener.js';

--- a/src/internal/ActRunnerParams.ts
+++ b/src/internal/ActRunnerParams.ts
@@ -20,7 +20,7 @@
  */
 
 import { WebhookEventName } from '@octokit/webhooks-types';
-import type { ActResourceServerSpec } from '../ActResourceServerSpec.js';
+import type { ActResourceServerSpec } from '../ActRunnerOptions.js';
 import { checkExists } from '../utils/checks.js';
 import { firstDefined } from '../utils/objects.js';
 

--- a/tests/config_validation.test.ts
+++ b/tests/config_validation.test.ts
@@ -1,8 +1,11 @@
 import { test, expect } from 'vitest';
 import { runner, workflowPath } from './fixtures.js';
+import { ActWorkflowSource } from '../src/index.js';
 
 test('fails if the specified workflows location does not exist', async () => {
-  await expect(runner().withWorkflowFile('non-existing').run()).rejects.toThrow(
+  await expect(
+    runner().withWorkflow({ file: 'non-existing' }).run(),
+  ).rejects.toThrow(
     "The specified workflow path 'non-existing' does not exist",
   );
 });
@@ -14,9 +17,13 @@ test('fails if the specified working directory does not exist', async () => {
 });
 
 test('fails if both the workflow file and workflow body are specified', async () => {
-  await expect(
-    runner().withWorkflowFile('file').withWorkflowBody('body').run(),
-  ).rejects.toThrow(
+  // bypasses the type system to exercise the runtime guard for untyped (e.g. plain JS) callers
+  const bothSpecified = {
+    file: 'file',
+    body: 'body',
+  } as unknown as ActWorkflowSource;
+
+  await expect(runner().withWorkflow(bothSpecified).run()).rejects.toThrow(
     "Expected one value out of 'file' and 'body' to be defined",
   );
 });
@@ -30,7 +37,7 @@ test('either workflow file or body is required', async () => {
 test('fails if provided env file does not exist', async () => {
   await expect(
     runner()
-      .withWorkflowFile(workflowPath('always_passing_workflow'))
+      .withWorkflow({ file: workflowPath('always_passing_workflow') })
       .withEnv({ file: 'non-existing' })
       .run(),
   ).rejects.toThrow(
@@ -41,7 +48,7 @@ test('fails if provided env file does not exist', async () => {
 test('fails if provided input values file does not exist', async () => {
   await expect(
     runner()
-      .withWorkflowFile(workflowPath('always_passing_workflow'))
+      .withWorkflow({ file: workflowPath('always_passing_workflow') })
       .withInputs({ file: 'non-existing' })
       .run(),
   ).rejects.toThrow(
@@ -52,7 +59,7 @@ test('fails if provided input values file does not exist', async () => {
 test('fails if provided event payload file does not exist', async () => {
   await expect(
     runner()
-      .withWorkflowFile(workflowPath('always_passing_workflow'))
+      .withWorkflow({ file: workflowPath('always_passing_workflow') })
       .withEvent('push', 'non-existing')
       .run(),
   ).rejects.toThrow(
@@ -63,7 +70,7 @@ test('fails if provided event payload file does not exist', async () => {
 test('fails if provided secrets values file does not exist', async () => {
   await expect(
     runner()
-      .withWorkflowFile(workflowPath('always_passing_workflow'))
+      .withWorkflow({ file: workflowPath('always_passing_workflow') })
       .withSecrets({ file: 'non-existing' })
       .run(),
   ).rejects.toThrow(
@@ -74,7 +81,7 @@ test('fails if provided secrets values file does not exist', async () => {
 test('fails if provided variables values file does not exist', async () => {
   await expect(
     runner()
-      .withWorkflowFile(workflowPath('always_passing_workflow'))
+      .withWorkflow({ file: workflowPath('always_passing_workflow') })
       .withVariables({ file: 'non-existing' })
       .run(),
   ).rejects.toThrow(
@@ -85,7 +92,7 @@ test('fails if provided variables values file does not exist', async () => {
 test('fails if additional arguments contain managed params', async () => {
   await expect(
     runner()
-      .withWorkflowFile(workflowPath('always_passing_workflow'))
+      .withWorkflow({ file: workflowPath('always_passing_workflow') })
       .withAdditionalArgs(
         '--detect-event',
         '--input-file',
@@ -101,7 +108,7 @@ test('fails if additional arguments contain managed params', async () => {
 test('fails if additional arguments contain internal params', async () => {
   await expect(
     runner()
-      .withWorkflowFile(workflowPath('always_passing_workflow'))
+      .withWorkflow({ file: workflowPath('always_passing_workflow') })
       .withAdditionalArgs('--rm')
       .run(),
   ).rejects.toThrow(

--- a/tests/custom_executable.test.ts
+++ b/tests/custom_executable.test.ts
@@ -8,7 +8,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 export async function run(executable: string): Promise<ActWorkflowExecResult> {
   return runner()
     .withActExecutable(executable)
-    .withWorkflowFile(workflowPath('always_passing_workflow'))
+    .withWorkflow({ file: workflowPath('always_passing_workflow') })
     .run();
 }
 
@@ -62,7 +62,7 @@ test('rejects if run() is called more than once on the same instance', async () 
   );
   const testRunner = runner()
     .withActExecutable(customExec)
-    .withWorkflowFile(workflowPath('always_passing_workflow'));
+    .withWorkflow({ file: workflowPath('always_passing_workflow') });
 
   await testRunner.run();
 

--- a/tests/workflows_artifact_server.test.ts
+++ b/tests/workflows_artifact_server.test.ts
@@ -6,9 +6,9 @@ import { tmpdir } from 'node:os';
 import { existsSync, mkdirSync, rmSync } from 'node:fs';
 
 function artifactServerWorkflowRunner(): ActRunner {
-  return runner().withWorkflowFile(
-    workflowPath('save_file_in_artifact_server'),
-  );
+  return runner().withWorkflow({
+    file: workflowPath('save_file_in_artifact_server'),
+  });
 }
 
 const artifactServerDir = join(

--- a/tests/workflows_cache.test.ts
+++ b/tests/workflows_cache.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { existsSync, mkdirSync, rmSync } from 'node:fs';
 
 function cacheWorkflowRunner(): ActRunner {
-  return runner().withWorkflowFile(workflowPath('save_file_in_cache'));
+  return runner().withWorkflow({ file: workflowPath('save_file_in_cache') });
 }
 
 const customCacheDir = join(tmpdir(), 'actTestRunner', 'workflows_cache');

--- a/tests/workflows_core.test.ts
+++ b/tests/workflows_core.test.ts
@@ -8,7 +8,7 @@ import { existsSync, mkdirSync, rmSync } from 'node:fs';
 export async function run(
   workflowFile: string,
 ): Promise<ActWorkflowExecResult> {
-  return runner().withWorkflowFile(workflowFile).run();
+  return runner().withWorkflow({ file: workflowFile }).run();
 }
 
 const customWorkingDir = join(tmpdir(), 'actTestRunner', 'workflows_core');
@@ -71,8 +71,8 @@ test('reports all jobs', async () => {
 
 test('supports defining workflow body instead of file', async () => {
   const result = await runner()
-    .withWorkflowBody(
-      `
+    .withWorkflow({
+      body: `
 name: Simple passing workflow
 on: [push]
 
@@ -83,7 +83,7 @@ jobs:
       - name: Successful step
         run: echo "Hello, World!"
   `,
-    )
+    })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
@@ -98,8 +98,8 @@ jobs:
 test('supports defining custom working directory', async () => {
   const result = await runner()
     .withWorkingDir(customWorkingDir)
-    .withWorkflowBody(
-      `
+    .withWorkflow({
+      body: `
 name: Simple passing workflow
 on: [push]
 
@@ -110,7 +110,7 @@ jobs:
       - name: Successful step
         run: echo "Hello, World!"
   `,
-    )
+    })
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);

--- a/tests/workflows_env.test.ts
+++ b/tests/workflows_env.test.ts
@@ -3,7 +3,7 @@ import { inputPath, runner, workflowPath } from './fixtures.js';
 import { ActExecStatus, ActRunner } from '../src/index.js';
 
 function envWorkflowRunner(): ActRunner {
-  return runner().withWorkflowFile(workflowPath('print_env_variables'));
+  return runner().withWorkflow({ file: workflowPath('print_env_variables') });
 }
 
 test('supports setting environment variable values directly', async () => {

--- a/tests/workflows_event.test.ts
+++ b/tests/workflows_event.test.ts
@@ -3,7 +3,9 @@ import { eventPayloadPath, runner, workflowPath } from './fixtures.js';
 import { ActExecStatus, ActRunner } from '../src/index.js';
 
 function eventWorkflowRunner(): ActRunner {
-  return runner().withWorkflowFile(workflowPath('print_issue_or_pr_title'));
+  return runner().withWorkflow({
+    file: workflowPath('print_issue_or_pr_title'),
+  });
 }
 
 test('uses the first event type lexicographically from workflow if no event type is set', async () => {

--- a/tests/workflows_input.test.ts
+++ b/tests/workflows_input.test.ts
@@ -3,7 +3,7 @@ import { inputPath, runner, workflowPath } from './fixtures.js';
 import { ActExecStatus, ActRunner } from '../src/index.js';
 
 function inputWorkflowRunner(): ActRunner {
-  return runner().withWorkflowFile(workflowPath('print_inputs'));
+  return runner().withWorkflow({ file: workflowPath('print_inputs') });
 }
 
 test('supports setting input values directly', async () => {

--- a/tests/workflows_matrix.test.ts
+++ b/tests/workflows_matrix.test.ts
@@ -3,7 +3,7 @@ import { runner, workflowPath } from './fixtures.js';
 import { ActExecStatus, ActRunner } from '../src/index.js';
 
 function matrixWorkflowRunner(): ActRunner {
-  return runner().withWorkflowFile(workflowPath('print_matrix_values'));
+  return runner().withWorkflow({ file: workflowPath('print_matrix_values') });
 }
 
 test('runs workflow with all matrix values by default', async () => {

--- a/tests/workflows_output_listener.test.ts
+++ b/tests/workflows_output_listener.test.ts
@@ -44,7 +44,7 @@ afterEach(() => {
 });
 
 test('does not forward output to console by default', async () => {
-  const result = await runner().withWorkflowBody(WORKFLOW_BODY).run();
+  const result = await runner().withWorkflow({ body: WORKFLOW_BODY }).run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   expect(result.output).toContain('Hello, World!');
@@ -53,7 +53,7 @@ test('does not forward output to console by default', async () => {
 
 test('forwards output to console when listener is not provided', async () => {
   const result = await runner()
-    .withWorkflowBody(WORKFLOW_BODY)
+    .withWorkflow({ body: WORKFLOW_BODY })
     .forwardOutput()
     .run();
 
@@ -66,7 +66,7 @@ test('forwards output to console when listener is not provided', async () => {
 
 test('forwards output to the specified custom listener', async () => {
   const result = await runner()
-    .withWorkflowBody(WORKFLOW_BODY)
+    .withWorkflow({ body: WORKFLOW_BODY })
     .forwardOutput(customListener)
     .run();
 
@@ -78,7 +78,7 @@ test('forwards output to the specified custom listener', async () => {
 
 test('supports combining multiple listeners', async () => {
   const result = await runner()
-    .withWorkflowBody(WORKFLOW_BODY)
+    .withWorkflow({ body: WORKFLOW_BODY })
     .forwardOutput([customListener, new StdStreamOutputListener()])
     .run();
 

--- a/tests/workflows_secrets.test.ts
+++ b/tests/workflows_secrets.test.ts
@@ -4,7 +4,7 @@ import { ActExecStatus, ActRunner } from '../src/index.js';
 
 function secretsWorkflowRunner(): ActRunner {
   return runner()
-    .withWorkflowFile(workflowPath('print_secrets'))
+    .withWorkflow({ file: workflowPath('print_secrets') })
     .withAdditionalArgs('--insecure-secrets');
 }
 

--- a/tests/workflows_variables.test.ts
+++ b/tests/workflows_variables.test.ts
@@ -3,7 +3,7 @@ import { inputPath, runner, workflowPath } from './fixtures.js';
 import { ActExecStatus, ActRunner } from '../src/index.js';
 
 function variablesWorkflowRunner(): ActRunner {
-  return runner().withWorkflowFile(workflowPath('print_variables'));
+  return runner().withWorkflow({ file: workflowPath('print_variables') });
 }
 
 test('supports setting workflow variables directly', async () => {


### PR DESCRIPTION
## Summary
- **BREAKING CHANGE.** `withWorkflowFile(path)` and `withWorkflowBody(body)` modeled the same "one concern, provided via file or inline body" choice as two separate methods, unlike `withEvent`'s "one concern, one call" convention.
- Merged into `withWorkflow(source)`, taking a discriminated union (`{ file: string } | { body: string }`):
  ```js
  // before
  .withWorkflowFile(path)
  .withWorkflowBody(body)
  // after
  .withWorkflow({ file: path })
  .withWorkflow({ body: body })
  ```
- `ActWorkflowSource` is exported since it's now part of the public method signature.
- The internal `workflowFile`/`workflowBody` fields collapsed into a single `workflowSource` field; the `checkOneDefined` validation now operates on the resolved source's fields instead of two separate instance fields. This preserves the runtime guard against a caller bypassing the type system (e.g. plain JS) and supplying both `file` and `body` at once — covered by an updated regression test.
- Updated all call sites in tests and the README examples in the same commit.

Stacked on #190. PR 13 of a stack addressing all findings in #178 (Phase 3, point 4). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`, `utils/*`), including the updated "both file and body specified" regression test — full e2e suite requires `act` + Docker, unavailable in this sandbox; updated e2e test call sites are verified via `types:check` passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965)_