### PR TITLE
feat!: convert forwardOutput to varargs of listeners

### DIFF
--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -227,18 +227,14 @@ export class ActRunner<
 
   /**
    * Forwards the act output to the supplied listeners.
-   * When the listener is unspecified, forwards the output to the console.
-   * @param outputListeners - output consumers.
+   * When no listener is specified, forwards the output to the console.
+   * @param listeners - output consumers.
    */
-  forwardOutput(
-    outputListeners:
-      ActOutputListener | ActOutputListener[] = new StdStreamOutputListener(),
-  ): this {
-    if (Array.isArray(outputListeners)) {
-      this.outputListener = new CompositeActOutputListener(outputListeners);
-    } else {
-      this.outputListener = outputListeners;
-    }
+  forwardOutput(...listeners: ActOutputListener[]): this {
+    this.outputListener =
+      listeners.length === 0
+        ? new StdStreamOutputListener()
+        : new CompositeActOutputListener(listeners);
     return this;
   }
 

--- a/tests/workflows_output_listener.test.ts
+++ b/tests/workflows_output_listener.test.ts
@@ -79,7 +79,7 @@ test('forwards output to the specified custom listener', async () => {
 test('supports combining multiple listeners', async () => {
   const result = await runner()
     .withWorkflow({ body: WORKFLOW_BODY })
-    .forwardOutput([customListener, new StdStreamOutputListener()])
+    .forwardOutput(customListener, new StdStreamOutputListener())
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);


### PR DESCRIPTION
## Summary
- **BREAKING CHANGE.** `forwardOutput(outputListeners: ActOutputListener | ActOutputListener[])` had a `T | T[]` union smell. Unlike the varargs-of-tuples misuse fixed for env/inputs/secrets/variables/matrix elsewhere in this stack, listeners genuinely are a homogeneous list, so varargs is the correct shape here:
  ```js
  // before
  .forwardOutput([listenerA, listenerB])
  // after
  .forwardOutput(listenerA, listenerB)
  ```
- Calling `forwardOutput()` with no arguments still defaults to forwarding to the console.
- Dropped the now-unneeded `Array.isArray` branch.
- Updated the one affected test call site.

Stacked on #191. PR 14 of a stack addressing all findings in #178 (Phase 3, point 5). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`, `utils/*`) — full e2e suite requires `act` + Docker, unavailable in this sandbox; updated e2e test call sites are verified via `types:check` passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965)_