### PR TITLE
feat!: change ActWorkflowExecResult.jobs from Map to Record

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ jobs:
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);
   expect(result.output).toContain('Hello, World!');
-  expect(result.jobs.size).toBe(1);
+  expect(Object.keys(result.jobs).length).toBe(1);
 
-  const successfulJob = result.job('successful_job')!;
+  const successfulJob = result.jobs['successful_job']!;
   expect(successfulJob.status).toBe(ActExecStatus.SUCCESS);
   expect(successfulJob.output).toContain('Hello, World!');
 });
@@ -76,7 +76,7 @@ jobs:
     .run();
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);
-  const job = result.job('print_pr_title')!;
+  const job = result.jobs['print_pr_title']!;
   expect(job.status).toBe(ActExecStatus.SUCCESS);
   expect(job.output).toContain('PR Title: Example PR payload as object');
 });
@@ -104,7 +104,7 @@ jobs:
     .run();
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting')!;
+  const job = result.jobs['print_greeting']!;
   expect(job.status).toBe(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hello, Bruce!');
 });

--- a/src/ActWorkflowExecResult.ts
+++ b/src/ActWorkflowExecResult.ts
@@ -35,25 +35,17 @@ export class ActWorkflowExecResult {
    */
   readonly output: string;
   /**
-   * Jobs executed by the workflow.
+   * Jobs executed by the workflow, keyed by job name.
    */
-  readonly jobs: Map<string, ActJobExecResult>;
+  readonly jobs: Record<string, ActJobExecResult>;
 
   constructor(
     status: ActExecStatus,
     output: string,
-    jobs: Map<string, ActJobExecResult>,
+    jobs: Record<string, ActJobExecResult>,
   ) {
     this.status = status;
     this.output = output;
     this.jobs = jobs;
-  }
-
-  /**
-   * @param name - name of the job executed by the given workflow.
-   * @returns job - result of executing the given job in the context of the current workflow.
-   */
-  job(name: string): ActJobExecResult | undefined {
-    return this.jobs.get(name);
   }
 }

--- a/src/internal/ActExecListener.ts
+++ b/src/internal/ActExecListener.ts
@@ -164,8 +164,8 @@ export class ActExecListener {
     return this.execOutput.join('\n');
   }
 
-  getJobs(): Map<string, ActJobExecResult> {
-    return new Map(
+  getJobs(): Record<string, ActJobExecResult> {
+    return Object.fromEntries(
       Array.from(this.jobsByName).map(([name, jobBuilder]) => [
         name,
         jobBuilder.build(),

--- a/tests/workflows_artifact_server.test.ts
+++ b/tests/workflows_artifact_server.test.ts
@@ -36,7 +36,7 @@ test('persists workflow artifacts in configured directory', async () => {
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(result.job('store_file_in_artifact_server')!.status).toBe(
+  expect(result.jobs['store_file_in_artifact_server']!.status).toBe(
     ActExecStatus.SUCCESS,
   );
 

--- a/tests/workflows_cache.test.ts
+++ b/tests/workflows_cache.test.ts
@@ -28,7 +28,7 @@ test('persists cache entries in configured directory', async () => {
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(result.job('store_file_in_cache')!).toHaveStatus(
+  expect(result.jobs['store_file_in_cache']!).toHaveStatus(
     ActExecStatus.SUCCESS,
   );
 

--- a/tests/workflows_core.test.ts
+++ b/tests/workflows_core.test.ts
@@ -29,9 +29,9 @@ test('reports successful workflows', async () => {
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   expect(result.output).toContain('Hello, World!');
-  expect(result.jobs.size).toBe(1);
+  expect(Object.keys(result.jobs).length).toBe(1);
 
-  const successfulJob = result.job('successful_job')!;
+  const successfulJob = result.jobs['successful_job']!;
   expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
   expect(successfulJob.output).toContain('Hello, World!');
 });
@@ -41,9 +41,9 @@ test('captures workflow failures', async () => {
 
   expect(result).toHaveStatus(ActExecStatus.FAILED);
   expect(result.output).toContain('Hello, World!');
-  expect(result.jobs.size).toBe(1);
+  expect(Object.keys(result.jobs).length).toBe(1);
 
-  const failingJob = result.job('failing_job')!;
+  const failingJob = result.jobs['failing_job']!;
   expect(failingJob).toHaveStatus(ActExecStatus.FAILED);
   expect(failingJob.output).toContain('Hello, World!');
 });
@@ -56,14 +56,14 @@ test('reports all jobs', async () => {
   expect(result).toHaveStatus(ActExecStatus.FAILED);
   expect(result.output).toContain('I succeed!');
   expect(result.output).toContain('I fail!');
-  expect(result.jobs.size).toBe(2);
+  expect(Object.keys(result.jobs).length).toBe(2);
 
-  const successfulJob = result.job('successful_job')!;
+  const successfulJob = result.jobs['successful_job']!;
   expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
   expect(successfulJob.output).toContain('I succeed!');
   expect(successfulJob.output).not.toContain('I fail!');
 
-  const failingJob = result.job('failing_job')!;
+  const failingJob = result.jobs['failing_job']!;
   expect(failingJob).toHaveStatus(ActExecStatus.FAILED);
   expect(failingJob.output).toContain('I fail!');
   expect(failingJob.output).not.toContain('I succeed!');
@@ -88,9 +88,9 @@ jobs:
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   expect(result.output).toContain('Hello, World!');
-  expect(result.jobs.size).toBe(1);
+  expect(Object.keys(result.jobs).length).toBe(1);
 
-  const successfulJob = result.job('successful_job')!;
+  const successfulJob = result.jobs['successful_job']!;
   expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
   expect(successfulJob.output).toContain('Hello, World!');
 });
@@ -115,9 +115,9 @@ jobs:
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
   expect(result.output).toContain('Hello, World!');
-  expect(result.jobs.size).toBe(1);
+  expect(Object.keys(result.jobs).length).toBe(1);
 
-  const successfulJob = result.job('successful_job')!;
+  const successfulJob = result.jobs['successful_job']!;
   expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
   expect(successfulJob.output).toContain('Hello, World!');
 });

--- a/tests/workflows_env.test.ts
+++ b/tests/workflows_env.test.ts
@@ -12,7 +12,7 @@ test('supports setting environment variable values directly', async () => {
     .run();
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting')!;
+  const job = result.jobs['print_greeting']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hello, Bruce!');
 });
@@ -23,7 +23,7 @@ test('supports setting environment variables from file', async () => {
     .run();
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting')!;
+  const job = result.jobs['print_greeting']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Falco!');
 });
@@ -36,7 +36,7 @@ test('supports combining a values file with inline overrides', async () => {
     .run();
 
   expect(result.status).toBe(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting')!;
+  const job = result.jobs['print_greeting']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Bruce!');
 });

--- a/tests/workflows_event.test.ts
+++ b/tests/workflows_event.test.ts
@@ -13,10 +13,10 @@ test('uses the first event type lexicographically from workflow if no event type
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
-  const issueJob = result.job('print_issue_title')!;
+  const issueJob = result.jobs['print_issue_title']!;
   expect(issueJob).toHaveStatus(ActExecStatus.SUCCESS);
 
-  const prJob = result.job('print_pr_title')!;
+  const prJob = result.jobs['print_pr_title']!;
   expect(prJob).toHaveStatus(ActExecStatus.SKIPPED);
 });
 
@@ -25,10 +25,10 @@ test('allows configuring the event type to trigger the workflow with', async () 
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
-  const issueJob = result.job('print_issue_title')!;
+  const issueJob = result.jobs['print_issue_title']!;
   expect(issueJob).toHaveStatus(ActExecStatus.SKIPPED);
 
-  const prJob = result.job('print_pr_title')!;
+  const prJob = result.jobs['print_pr_title']!;
   expect(prJob).toHaveStatus(ActExecStatus.SUCCESS);
 });
 
@@ -39,10 +39,10 @@ test('allows configuring event payload', async () => {
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
-  const issueJob = result.job('print_issue_title')!;
+  const issueJob = result.jobs['print_issue_title']!;
   expect(issueJob).toHaveStatus(ActExecStatus.SKIPPED);
 
-  const prJob = result.job('print_pr_title')!;
+  const prJob = result.jobs['print_pr_title']!;
   expect(prJob).toHaveStatus(ActExecStatus.SUCCESS);
   expect(prJob.output).toContain('PR Title: Example PR payload');
 });
@@ -58,10 +58,10 @@ test('allows passing event payload as object', async () => {
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
-  const issueJob = result.job('print_issue_title')!;
+  const issueJob = result.jobs['print_issue_title']!;
   expect(issueJob).toHaveStatus(ActExecStatus.SKIPPED);
 
-  const prJob = result.job('print_pr_title')!;
+  const prJob = result.jobs['print_pr_title']!;
   expect(prJob).toHaveStatus(ActExecStatus.SUCCESS);
   expect(prJob.output).toContain('PR Title: Example PR payload as object');
 });

--- a/tests/workflows_input.test.ts
+++ b/tests/workflows_input.test.ts
@@ -12,7 +12,7 @@ test('supports setting input values directly', async () => {
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting')!;
+  const job = result.jobs['print_greeting']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hello, Bruce!');
 });
@@ -23,7 +23,7 @@ test('supports setting input values from file', async () => {
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting')!;
+  const job = result.jobs['print_greeting']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Falco!');
 });
@@ -39,7 +39,7 @@ test('supports combining a values file with inline overrides', async () => {
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting')!;
+  const job = result.jobs['print_greeting']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Bruce!');
 });

--- a/tests/workflows_matrix.test.ts
+++ b/tests/workflows_matrix.test.ts
@@ -11,7 +11,7 @@ test('runs workflow with all matrix values by default', async () => {
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
-  const matrixJobs = Array.from(result.jobs.values()).filter((job) =>
+  const matrixJobs = Object.values(result.jobs).filter((job) =>
     job.name.startsWith('print_greeting'),
   );
   expect(matrixJobs.map((it) => it.name)).toEqual([
@@ -37,7 +37,7 @@ test('supports restricting matrix values to run with', async () => {
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting_1')!;
+  const job = result.jobs['print_greeting_1']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Bruce!');
 });

--- a/tests/workflows_secrets.test.ts
+++ b/tests/workflows_secrets.test.ts
@@ -14,7 +14,7 @@ test('supports setting secrets values directly', async () => {
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting')!;
+  const job = result.jobs['print_greeting']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hello, Bruce!');
 });
@@ -25,7 +25,7 @@ test('supports setting secrets values from file', async () => {
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting')!;
+  const job = result.jobs['print_greeting']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Falco!');
 });
@@ -42,7 +42,7 @@ test('supports combining a values file with inline overrides', async () => {
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting')!;
+  const job = result.jobs['print_greeting']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Bruce!');
 });

--- a/tests/workflows_variables.test.ts
+++ b/tests/workflows_variables.test.ts
@@ -12,7 +12,7 @@ test('supports setting workflow variables directly', async () => {
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting')!;
+  const job = result.jobs['print_greeting']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hello, Bruce!');
 });
@@ -23,7 +23,7 @@ test('supports setting workflow variables from file', async () => {
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting')!;
+  const job = result.jobs['print_greeting']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Falco!');
 });
@@ -40,7 +40,7 @@ test('supports combining a values file with inline overrides', async () => {
     .run();
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.job('print_greeting')!;
+  const job = result.jobs['print_greeting']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Bruce!');
 });


### PR DESCRIPTION
## Summary
- **BREAKING CHANGE.** `ActWorkflowExecResult` exposed both a public `Map` field (`jobs`) and a redundant `.job(name)` accessor that just called `.get()` on it — two ways to do the same thing, and `Map` is a heavier abstraction than needed for a fixed collection of results keyed by job name.
- Changed `jobs` to a plain `Record<string, ActJobExecResult>` and dropped `.job(name)` in favor of direct property/bracket access:
  ```js
  // before
  result.jobs.size
  result.job('my_job')
  // after
  Object.keys(result.jobs).length
  result.jobs['my_job']
  ```
- Updated `ActExecListener.getJobs()` to build a `Record` instead of a `Map`, and all call sites in tests and the README.

Stacked on #192. PR 15 of a stack addressing all findings in #178 (Phase 3, point 6). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`, `utils/*`) — full e2e suite requires `act` + Docker, unavailable in this sandbox; updated e2e test call sites are verified via `types:check` passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965)_