### PR TITLE
refactor: flatten ActRunnerParams's constructor and rename it to ActCliParams

### DIFF
--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -351,22 +351,22 @@ export class ActRunner<
       );
     }
 
-    return new ActRunnerParams(
-      workflowFilePath,
+    return new ActRunnerParams({
+      workflowsPath: workflowFilePath,
       eventPayloadFilePath,
-      this.eventType,
-      this.envFile,
-      this.envValues,
-      this.inputsFile,
-      this.inputsValues,
-      this.secretsFile,
-      this.secretsValues,
-      this.variablesFile,
-      this.variablesValues,
-      this.matrix,
-      this.cacheServer,
-      this.artifactServer,
-      this.additionalArgs,
-    );
+      eventType: this.eventType,
+      envFile: this.envFile,
+      envValues: this.envValues,
+      inputFile: this.inputsFile,
+      inputValues: this.inputsValues,
+      secretsFile: this.secretsFile,
+      secretsValues: this.secretsValues,
+      variablesFile: this.variablesFile,
+      variablesValues: this.variablesValues,
+      matrix: this.matrix,
+      cacheServer: this.cacheServer,
+      artifactServer: this.artifactServer,
+      additionalArgs: this.additionalArgs,
+    });
   }
 }

--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -40,10 +40,10 @@ import type {
   ActResourceServerSpec,
 } from './ActRunnerOptions.js';
 import {
-  ActRunnerParams,
+  ActCliParams,
   INTERNAL_ACT_PARAMS,
   MANAGED_ACT_PARAMS,
-} from './internal/ActRunnerParams.js';
+} from './internal/ActCliParams.js';
 import {
   ActOutputListener,
   CompositeActOutputListener,
@@ -295,7 +295,7 @@ export class ActRunner<
     });
   }
 
-  private validateRunnerParams(): ActRunnerParams<TEventType> {
+  private validateRunnerParams(): ActCliParams<TEventType> {
     if (this.actExecutable) {
       checkExists('act executable', this.actExecutable);
     }
@@ -351,7 +351,7 @@ export class ActRunner<
       );
     }
 
-    return new ActRunnerParams({
+    return new ActCliParams({
       workflowsPath: workflowFilePath,
       eventPayloadFilePath,
       eventType: this.eventType,

--- a/src/internal/ActCliParams.ts
+++ b/src/internal/ActCliParams.ts
@@ -50,7 +50,7 @@ export const MANAGED_ACT_PARAMS: Set<string> = new Set([
 
 export const INTERNAL_ACT_PARAMS: Set<string> = new Set(['--rm', '--json']);
 
-export type ActRunnerParamsInput<
+export type ActCliParamsInput<
   EventType extends WebhookEventName | undefined = undefined,
 > = {
   workflowsPath: string;
@@ -70,7 +70,7 @@ export type ActRunnerParamsInput<
   additionalArgs: string[];
 };
 
-export class ActRunnerParams<
+export class ActCliParams<
   EventType extends WebhookEventName | undefined = undefined,
 > {
   private readonly workflowsPath: string;
@@ -89,7 +89,7 @@ export class ActRunnerParams<
   private readonly artifactServer: ActResourceServerSpec | undefined;
   private readonly additionalArgs: string[];
 
-  constructor(params: ActRunnerParamsInput<EventType>) {
+  constructor(params: ActCliParamsInput<EventType>) {
     this.workflowsPath = params.workflowsPath;
     this.eventType = params.eventType;
     this.eventPayloadFilePath = params.eventPayloadFilePath;

--- a/src/internal/ActRunnerParams.ts
+++ b/src/internal/ActRunnerParams.ts
@@ -50,6 +50,26 @@ export const MANAGED_ACT_PARAMS: Set<string> = new Set([
 
 export const INTERNAL_ACT_PARAMS: Set<string> = new Set(['--rm', '--json']);
 
+export type ActRunnerParamsInput<
+  EventType extends WebhookEventName | undefined = undefined,
+> = {
+  workflowsPath: string;
+  eventPayloadFilePath: string | undefined;
+  eventType: EventType | undefined;
+  envFile: string | undefined;
+  envValues: Map<string, string>;
+  inputFile: string | undefined;
+  inputValues: Map<string, string>;
+  secretsFile: string | undefined;
+  secretsValues: Map<string, string>;
+  variablesFile: string | undefined;
+  variablesValues: Map<string, string>;
+  matrix: Map<string, string | number | boolean>;
+  cacheServer: ActResourceServerSpec | undefined;
+  artifactServer: ActResourceServerSpec | undefined;
+  additionalArgs: string[];
+};
+
 export class ActRunnerParams<
   EventType extends WebhookEventName | undefined = undefined,
 > {
@@ -69,38 +89,22 @@ export class ActRunnerParams<
   private readonly artifactServer: ActResourceServerSpec | undefined;
   private readonly additionalArgs: string[];
 
-  constructor(
-    workflowsPath: string,
-    eventPayloadFilePath: string | undefined,
-    eventType: EventType | undefined,
-    envFile: string | undefined,
-    envValues: Map<string, string>,
-    inputFile: string | undefined,
-    inputValues: Map<string, string>,
-    secretsFile: string | undefined,
-    secretsValues: Map<string, string>,
-    variablesFile: string | undefined,
-    variablesValues: Map<string, string>,
-    matrix: Map<string, string | number | boolean>,
-    cacheServer: ActResourceServerSpec | undefined,
-    artifactServer: ActResourceServerSpec | undefined,
-    additionalArgs: string[],
-  ) {
-    this.workflowsPath = workflowsPath;
-    this.eventType = eventType;
-    this.eventPayloadFilePath = eventPayloadFilePath;
-    this.envFile = envFile;
-    this.envValues = envValues;
-    this.inputFile = inputFile;
-    this.inputValues = inputValues;
-    this.secretsFile = secretsFile;
-    this.secretsValues = secretsValues;
-    this.variablesFile = variablesFile;
-    this.variablesValues = variablesValues;
-    this.matrix = matrix;
-    this.cacheServer = cacheServer;
-    this.artifactServer = artifactServer;
-    this.additionalArgs = additionalArgs;
+  constructor(params: ActRunnerParamsInput<EventType>) {
+    this.workflowsPath = params.workflowsPath;
+    this.eventType = params.eventType;
+    this.eventPayloadFilePath = params.eventPayloadFilePath;
+    this.envFile = params.envFile;
+    this.envValues = params.envValues;
+    this.inputFile = params.inputFile;
+    this.inputValues = params.inputValues;
+    this.secretsFile = params.secretsFile;
+    this.secretsValues = params.secretsValues;
+    this.variablesFile = params.variablesFile;
+    this.variablesValues = params.variablesValues;
+    this.matrix = params.matrix;
+    this.cacheServer = params.cacheServer;
+    this.artifactServer = params.artifactServer;
+    this.additionalArgs = params.additionalArgs;
   }
 
   asCliArgs(): string[] {


### PR DESCRIPTION
## Summary
- `ActRunnerParams` took a 15-parameter positional constructor, which is hard to call correctly and easy to get subtly wrong (e.g. swapping two adjacent same-typed arguments like `envFile`/`inputFile`).
- Internal-only class (not exported from `index.ts`), so no public API impact — but it's touched by the other Phase 3 changes anyway, so bundled in per the plan in #178 rather than doing a second pass later.
- Flattened into a single `ActRunnerParamsInput` options object; updated the one call site in `ActRunner.ts` to match.
- **Also renamed the class to `ActCliParams`** (and its options type to `ActCliParamsInput`, and the file to `internal/ActCliParams.ts`): the class doesn't hold parameters passed *to* an `ActRunner` — it translates `ActRunner`'s resolved state into `act` CLI arguments (`asCliArgs()`). `ActCliParams` names what it actually is. `ActRunner`'s own `validateRunnerParams()` method name is left unchanged since it refers to the general concept, not this class.

Stacked on #193. PR 16 of a stack addressing all findings in #178 (Phase 3, point 7 — completes Phase 3, the breaking-change phase). Part of #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable`, `utils/*`) — full e2e suite requires `act` + Docker, unavailable in this sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965