### PR TITLE
feat: support aborting a running act invocation via AbortSignal

### DIFF
--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -57,6 +57,18 @@ type EventPayload<TEventType extends WebhookEventName | undefined = undefined> =
   | undefined;
 
 /**
+ * Options controlling a single `run()` invocation.
+ */
+export type ActRunOptions = {
+  /**
+   * Signal used to abort a running act invocation. On abort, the underlying
+   * act process is killed and the returned promise rejects with an
+   * ActRunnerError.
+   */
+  signal?: AbortSignal;
+};
+
+/**
  * Invokes `act`, allowing end-to-end testing of custom GitHub actions and workflows.
  *
  * Typically, the test code will provide a workflow file or workflow body to run, as well as required workflow inputs, such as environment variables or secrets.
@@ -240,9 +252,10 @@ export class ActRunner<
 
   /**
    * Invokes `act` with specified options.
+   * @param options - options controlling this run, such as an abort signal
    * @returns workflow execution result for inspection
    */
-  run(): Promise<ActWorkflowExecResult> {
+  run(options?: ActRunOptions): Promise<ActWorkflowExecResult> {
     return new Promise<ActWorkflowExecResult>((resolve, reject) => {
       try {
         if (this.hasRun) {
@@ -252,6 +265,11 @@ export class ActRunner<
         }
         this.hasRun = true;
 
+        const signal = options?.signal;
+        if (signal?.aborted) {
+          throw new ActRunnerError('act execution was aborted');
+        }
+
         const params = this.validateRunnerParams();
 
         const executionListener = new ActExecListener(this.outputListener);
@@ -259,6 +277,11 @@ export class ActRunner<
         // apply user arguments + additional internal arguments specific to test execution
         const args = [...params.asCliArgs(), '--rm', '--json'];
         const child = spawn(this.actExecutable ?? 'act', args);
+
+        const onAbort = () => {
+          child.kill();
+        };
+        signal?.addEventListener('abort', onAbort, { once: true });
 
         child.stdout.on('data', (data) =>
           executionListener.onRawOutput(data.toString().trimEnd()),
@@ -268,7 +291,12 @@ export class ActRunner<
         );
 
         child.on('close', (code) => {
+          signal?.removeEventListener('abort', onAbort);
           cleanupDir(this.workingDir!);
+          if (signal?.aborted) {
+            reject(new ActRunnerError('act execution was aborted'));
+            return;
+          }
           resolve(
             new ActWorkflowExecResult(
               code === 0 ? ActExecStatus.SUCCESS : ActExecStatus.FAILED,
@@ -279,6 +307,7 @@ export class ActRunner<
         });
 
         child.on('error', (err) => {
+          signal?.removeEventListener('abort', onAbort);
           reject(new ActRunnerError(`Failed to launch act: ${err.message}`));
         });
       } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export type {
   ActWorkflowSource,
   ActResourceServerSpec,
 } from './ActRunnerOptions.js';
+export type { ActRunOptions } from './ActRunner.js';
 export { ActRunnerError } from './ActRunnerError.js';
 export { ActWorkflowExecResult } from './ActWorkflowExecResult.js';
 export type { ActOutputListener, ActOutput } from './ActOutputListener.js';

--- a/tests/custom_executable.test.ts
+++ b/tests/custom_executable.test.ts
@@ -70,3 +70,23 @@ test('rejects if run() is called more than once on the same instance', async () 
     'ActRunner instances cannot be reused; create a new instance for each run()',
   );
 });
+
+test('rejects and kills the process when the abort signal fires', async () => {
+  const customExec = join(customExecDir, 'slowAct');
+  writeFileSync(
+    customExec,
+    `#!/usr/bin/env bash
+    sleep 30
+  `,
+    { mode: 0o744 },
+  );
+  const controller = new AbortController();
+  const resultPromise = runner()
+    .withActExecutable(customExec)
+    .withWorkflow({ file: workflowPath('always_passing_workflow') })
+    .run({ signal: controller.signal });
+
+  controller.abort();
+
+  await expect(resultPromise).rejects.toThrow('act execution was aborted');
+});


### PR DESCRIPTION
## Summary
- There was no way for calling code to abort a hung or long-running `act` invocation. Idiomatic modern Node async APIs (`fetch`, `child_process` promise helpers) accept an `AbortSignal`, so `run()` now does too:
  ```js
  const controller = new AbortController();
  const resultPromise = runner.run({ signal: controller.signal });
  controller.abort();
  ```
- On abort, the underlying `act` process is killed and the returned promise rejects with an `ActRunnerError`. Passing an already-aborted signal rejects immediately without spawning `act`.
- `ActRunOptions` is exported. The parameter is optional, so this is purely additive and non-breaking (no version bump needed).
- Added a regression test using a slow custom executable (`sleep 30`) that verifies the process is actually killed — the test completes in milliseconds rather than waiting out the full sleep.

Stacked on #194. Final PR (17 of 17) of the stack addressing all findings in #178 (Phase 4 stretch goal). Closes #178.

## Test plan
- [x] `pnpm run check:all` (lint, prettier, types)
- [x] `pnpm run test` on files that don't require Docker/`act` (`config_validation`, `custom_executable` including the new abort regression test, `utils/*`) — full e2e suite requires `act` + Docker, unavailable in this sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFAWQMdE9G6fxLtgiEs965)_