### PR TITLE
feat: capture matrix values on job execution results

### DIFF
--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -48,7 +48,10 @@ import {
   StdStreamOutputListener,
 } from './ActOutputListener.js';
 import { ActExecStatus, ActRunnerError } from './ActRunnerResult.js';
-import type { ActWorkflowExecResult } from './ActRunnerResult.js';
+import type {
+  ActMatrixValues,
+  ActWorkflowExecResult,
+} from './ActRunnerResult.js';
 
 type EventPayload<TEventType extends WebhookEventName | undefined = undefined> =
   | (TEventType extends WebhookEventName
@@ -191,7 +194,7 @@ export class ActRunner<
    * If undefined, all combinations specified in the workflow definition will be invoked.
    * @param matrixValues - matrix values to run the workflow with
    */
-  withMatrix(matrixValues: Record<string, string | number | boolean>): this {
+  withMatrix(matrixValues: ActMatrixValues): this {
     Object.entries(matrixValues).forEach(([key, value]) =>
       this.matrix.set(key, value),
     );

--- a/src/ActRunnerResult.ts
+++ b/src/ActRunnerResult.ts
@@ -20,6 +20,11 @@
  */
 
 /**
+ * Matrix values a job ran with.
+ */
+export type ActMatrixValues = Record<string, string | number | boolean>;
+
+/**
  * Result of the workflow execution.
  */
 export type ActWorkflowExecResult = {
@@ -67,6 +72,10 @@ export type ActJobExecResult = {
    * Job's console output.
    */
   readonly output: string;
+  /**
+   * Matrix values the job ran with.
+   */
+  readonly matrix: ActMatrixValues;
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,5 +34,6 @@ export {
 export { ActExecStatus, ActRunnerError } from './ActRunnerResult.js';
 export type {
   ActJobExecResult,
+  ActMatrixValues,
   ActWorkflowExecResult,
 } from './ActRunnerResult.js';

--- a/src/internal/ActExecListener.ts
+++ b/src/internal/ActExecListener.ts
@@ -24,7 +24,7 @@ import {
   ActOutputLevel,
   ActOutputListener,
 } from '../ActOutputListener.js';
-import type { ActJobExecResult } from '../ActRunnerResult.js';
+import type { ActJobExecResult, ActMatrixValues } from '../ActRunnerResult.js';
 import { ActJobExecResultBuilder } from './ActJobExecResultBuilder.js';
 import { formattedMessage } from './outputFormatter.js';
 
@@ -39,7 +39,7 @@ type JsonOutput = {
   jobResult?: JobOrStepResult;
   step?: string;
   stepResult?: JobOrStepResult;
-  matrix: Record<string, string>;
+  matrix: ActMatrixValues;
 };
 
 const JOB_LIFECYCLE_STEPS = new Set<string>(['Set up job', 'Complete job']);
@@ -47,13 +47,14 @@ const JOB_LIFECYCLE_STEPS = new Set<string>(['Set up job', 'Complete job']);
 class JobIterationTracker {
   private readonly matrixIdx: Map<string, number> = new Map<string, number>();
 
-  private matrixKey(matrix: Record<string, string>): string {
-    return Object.values(matrix)
+  private matrixKey(matrix: ActMatrixValues): string {
+    return Object.entries(matrix)
+      .map((value) => `${value[0]}\u0000${value[1]}`)
       .sort((a, b) => (a > b ? 1 : -1))
-      .reduce((prev, curr) => `${prev}_${curr}`);
+      .reduce((prev, curr) => `${prev}\u0000${curr}`);
   }
 
-  iterationIndex(matrix: Record<string, string>): number {
+  iterationIndex(matrix: ActMatrixValues): number {
     const key = this.matrixKey(matrix);
     if (this.matrixIdx.has(key)) {
       return this.matrixIdx.get(key)!;
@@ -107,16 +108,7 @@ export class ActExecListener {
     const msg = formattedMessage(output.msg, output.job);
     this.execOutput.push(msg);
     if (this.hasJobContext(output)) {
-      const iterationNumber = this.getJobIterationIdx(
-        output.jobID!,
-        output.matrix,
-      );
-      const jobName =
-        iterationNumber === undefined
-          ? output.jobID!
-          : `${output.jobID}_${iterationNumber}`;
-
-      const jobBuilder = this.createOrGetBuilder(jobName);
+      const jobBuilder = this.createOrGetBuilder(output.jobID!, output.matrix);
 
       jobBuilder.output(msg);
 
@@ -173,16 +165,26 @@ export class ActExecListener {
     );
   }
 
-  private createOrGetBuilder(jobName: string): ActJobExecResultBuilder {
+  private createOrGetBuilder(
+    jobId: string,
+    matrix: ActMatrixValues,
+  ): ActJobExecResultBuilder {
+    const iterationNumber = this.getJobIterationIdx(jobId, matrix);
+    const jobName =
+      iterationNumber === undefined ? jobId : `${jobId}_${iterationNumber}`;
+
     if (!this.jobsByName.has(jobName)) {
-      this.jobsByName.set(jobName, new ActJobExecResultBuilder(jobName));
+      this.jobsByName.set(
+        jobName,
+        new ActJobExecResultBuilder(jobName, matrix),
+      );
     }
     return this.jobsByName.get(jobName)!;
   }
 
   private getJobIterationIdx(
     jobName: string,
-    matrix: Record<string, string>,
+    matrix: ActMatrixValues,
   ): number | undefined {
     if (Object.keys(matrix).length == 0) {
       return undefined;

--- a/src/internal/ActJobExecResultBuilder.ts
+++ b/src/internal/ActJobExecResultBuilder.ts
@@ -20,16 +20,18 @@
  */
 
 import { ActExecStatus } from '../ActRunnerResult.js';
-import type { ActJobExecResult } from '../ActRunnerResult.js';
+import type { ActJobExecResult, ActMatrixValues } from '../ActRunnerResult.js';
 
 export class ActJobExecResultBuilder {
   private readonly name: string;
+  private readonly matrix: ActMatrixValues;
   private hasExecutedSteps: boolean = false;
   private status: ActExecStatus | undefined;
   private readonly outputLines: string[] = [];
 
-  constructor(name: string) {
+  constructor(name: string, matrix: ActMatrixValues) {
     this.name = name;
+    this.matrix = matrix;
   }
 
   output(line: string): ActJobExecResultBuilder {
@@ -59,6 +61,7 @@ export class ActJobExecResultBuilder {
       name: this.name,
       status: this.status!,
       output: this.outputLines.join('\n'),
+      matrix: this.matrix,
     };
   }
 }

--- a/tests/resources/workflows/different_matrix_value_types.yml
+++ b/tests/resources/workflows/different_matrix_value_types.yml
@@ -1,0 +1,14 @@
+name: Simple workflow using different types of matrix values
+on: [push]
+
+jobs:
+  a_job:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        number: [11, 22]
+        string: ['foo', 'bar']
+        boolean: [false, true]
+    steps:
+      - name: Irrelevant
+        run: echo "Irrelevant"

--- a/tests/workflows_core.test.ts
+++ b/tests/workflows_core.test.ts
@@ -34,6 +34,7 @@ test('reports successful workflows', async () => {
   const successfulJob = result.jobs['successful_job']!;
   expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
   expect(successfulJob.output).toContain('Hello, World!');
+  expect(successfulJob.matrix).toStrictEqual({});
 });
 
 test('captures workflow failures', async () => {

--- a/tests/workflows_matrix.test.ts
+++ b/tests/workflows_matrix.test.ts
@@ -11,8 +11,9 @@ test('runs workflow with all matrix values by default', async () => {
 
   expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
-  const matrixJobs = Object.values(result.jobs).filter((job) =>
-    job.name.startsWith('print_greeting'),
+  const matrixJobs = Object.values(result.jobs);
+  expect(matrixJobs.every((job) => job.status === ActExecStatus.SUCCESS)).toBe(
+    true,
   );
   expect(matrixJobs.map((it) => it.name)).toEqual([
     'print_greeting_1',
@@ -20,15 +21,18 @@ test('runs workflow with all matrix values by default', async () => {
     'print_greeting_3',
     'print_greeting_4',
   ]);
-  expect(matrixJobs.every((job) => job.status === ActExecStatus.SUCCESS)).toBe(
-    true,
-  );
 
-  const allOutput = matrixJobs.map((job) => job.output).join('\n');
-  expect(allOutput).toContain('Hello, Bruce!');
-  expect(allOutput).toContain('Hello, Falco!');
-  expect(allOutput).toContain('Hallo, Bruce!');
-  expect(allOutput).toContain('Hallo, Falco!');
+  const job1 = matrixJobs.find((job) => job.output.includes('Hello, Bruce!'))!;
+  expect(job1.matrix).toStrictEqual({ greeting: 'Hello', name: 'Bruce' });
+
+  const job2 = matrixJobs.find((job) => job.output.includes('Hello, Falco!'))!;
+  expect(job2.matrix).toStrictEqual({ greeting: 'Hello', name: 'Falco' });
+
+  const job3 = matrixJobs.find((job) => job.output.includes('Hallo, Bruce!'))!;
+  expect(job3.matrix).toStrictEqual({ greeting: 'Hallo', name: 'Bruce' });
+
+  const job4 = matrixJobs.find((job) => job.output.includes('Hallo, Falco!'))!;
+  expect(job4.matrix).toStrictEqual({ greeting: 'Hallo', name: 'Falco' });
 });
 
 test('supports restricting matrix values to run with', async () => {
@@ -40,4 +44,25 @@ test('supports restricting matrix values to run with', async () => {
   const job = result.jobs['print_greeting_1']!;
   expect(job).toHaveStatus(ActExecStatus.SUCCESS);
   expect(job.output).toContain('Hallo, Bruce!');
+  expect(job.matrix).toStrictEqual({
+    greeting: 'Hallo',
+    name: 'Bruce',
+  });
+});
+
+test('captures all supported matrix value types', async () => {
+  const matrix = {
+    number: 22,
+    string: 'foo',
+    boolean: false,
+  };
+  const result = await runner()
+    .withWorkflow({ file: workflowPath('different_matrix_value_types') })
+    .withMatrix(matrix)
+    .run();
+
+  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+  const job = result.jobs['a_job_1']!;
+  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+  expect(job.matrix).toStrictEqual(matrix);
 });


### PR DESCRIPTION
Expose the matrix combination each job ran with via ActJobExecResult.matrix,
so consumers no longer need to infer it from job output. Also disambiguates
matrix iteration keys with a NUL delimiter to avoid collisions between
similarly-shaped key/value pairs.

Closes #171
