### PR TITLE
test: wrap tests in each file with a top-level describe block

### DIFF
--- a/tests/config_validation.test.ts
+++ b/tests/config_validation.test.ts
@@ -1,117 +1,119 @@
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 import { runner, workflowPath } from './fixtures.js';
 import { ActWorkflowSource } from '../src/index.js';
 
-test('fails if the specified workflows location does not exist', async () => {
-  await expect(
-    runner().withWorkflow({ file: 'non-existing' }).run(),
-  ).rejects.toThrow(
-    "The specified workflow path 'non-existing' does not exist",
-  );
-});
+describe('config validation', () => {
+  test('fails if the specified workflows location does not exist', async () => {
+    await expect(
+      runner().withWorkflow({ file: 'non-existing' }).run(),
+    ).rejects.toThrow(
+      "The specified workflow path 'non-existing' does not exist",
+    );
+  });
 
-test('fails if the specified working directory does not exist', async () => {
-  await expect(runner().withWorkingDir('non-existing').run()).rejects.toThrow(
-    "The specified working directory 'non-existing' does not exist",
-  );
-});
+  test('fails if the specified working directory does not exist', async () => {
+    await expect(runner().withWorkingDir('non-existing').run()).rejects.toThrow(
+      "The specified working directory 'non-existing' does not exist",
+    );
+  });
 
-test('fails if both the workflow file and workflow body are specified', async () => {
-  // bypasses the type system to exercise the runtime guard for untyped (e.g. plain JS) callers
-  const bothSpecified = {
-    file: 'file',
-    body: 'body',
-  } as unknown as ActWorkflowSource;
+  test('fails if both the workflow file and workflow body are specified', async () => {
+    // bypasses the type system to exercise the runtime guard for untyped (e.g. plain JS) callers
+    const bothSpecified = {
+      file: 'file',
+      body: 'body',
+    } as unknown as ActWorkflowSource;
 
-  await expect(runner().withWorkflow(bothSpecified).run()).rejects.toThrow(
-    "Expected one value out of 'file' and 'body' to be defined",
-  );
-});
+    await expect(runner().withWorkflow(bothSpecified).run()).rejects.toThrow(
+      "Expected one value out of 'file' and 'body' to be defined",
+    );
+  });
 
-test('either workflow file or body is required', async () => {
-  await expect(runner().run()).rejects.toThrow(
-    "Expected one value out of 'undefined' and 'undefined' to be defined",
-  );
-});
+  test('either workflow file or body is required', async () => {
+    await expect(runner().run()).rejects.toThrow(
+      "Expected one value out of 'undefined' and 'undefined' to be defined",
+    );
+  });
 
-test('fails if provided env file does not exist', async () => {
-  await expect(
-    runner()
-      .withWorkflow({ file: workflowPath('always_passing_workflow') })
-      .withEnv({ file: 'non-existing' })
-      .run(),
-  ).rejects.toThrow(
-    "The specified env values file 'non-existing' does not exist",
-  );
-});
+  test('fails if provided env file does not exist', async () => {
+    await expect(
+      runner()
+        .withWorkflow({ file: workflowPath('always_passing_workflow') })
+        .withEnv({ file: 'non-existing' })
+        .run(),
+    ).rejects.toThrow(
+      "The specified env values file 'non-existing' does not exist",
+    );
+  });
 
-test('fails if provided input values file does not exist', async () => {
-  await expect(
-    runner()
-      .withWorkflow({ file: workflowPath('always_passing_workflow') })
-      .withInputs({ file: 'non-existing' })
-      .run(),
-  ).rejects.toThrow(
-    "The specified input values file 'non-existing' does not exist",
-  );
-});
+  test('fails if provided input values file does not exist', async () => {
+    await expect(
+      runner()
+        .withWorkflow({ file: workflowPath('always_passing_workflow') })
+        .withInputs({ file: 'non-existing' })
+        .run(),
+    ).rejects.toThrow(
+      "The specified input values file 'non-existing' does not exist",
+    );
+  });
 
-test('fails if provided event payload file does not exist', async () => {
-  await expect(
-    runner()
-      .withWorkflow({ file: workflowPath('always_passing_workflow') })
-      .withEvent('push', 'non-existing')
-      .run(),
-  ).rejects.toThrow(
-    "The specified event payload file 'non-existing' does not exist",
-  );
-});
+  test('fails if provided event payload file does not exist', async () => {
+    await expect(
+      runner()
+        .withWorkflow({ file: workflowPath('always_passing_workflow') })
+        .withEvent('push', 'non-existing')
+        .run(),
+    ).rejects.toThrow(
+      "The specified event payload file 'non-existing' does not exist",
+    );
+  });
 
-test('fails if provided secrets values file does not exist', async () => {
-  await expect(
-    runner()
-      .withWorkflow({ file: workflowPath('always_passing_workflow') })
-      .withSecrets({ file: 'non-existing' })
-      .run(),
-  ).rejects.toThrow(
-    "The specified secrets values file 'non-existing' does not exist",
-  );
-});
+  test('fails if provided secrets values file does not exist', async () => {
+    await expect(
+      runner()
+        .withWorkflow({ file: workflowPath('always_passing_workflow') })
+        .withSecrets({ file: 'non-existing' })
+        .run(),
+    ).rejects.toThrow(
+      "The specified secrets values file 'non-existing' does not exist",
+    );
+  });
 
-test('fails if provided variables values file does not exist', async () => {
-  await expect(
-    runner()
-      .withWorkflow({ file: workflowPath('always_passing_workflow') })
-      .withVariables({ file: 'non-existing' })
-      .run(),
-  ).rejects.toThrow(
-    "The specified variables values file 'non-existing' does not exist",
-  );
-});
+  test('fails if provided variables values file does not exist', async () => {
+    await expect(
+      runner()
+        .withWorkflow({ file: workflowPath('always_passing_workflow') })
+        .withVariables({ file: 'non-existing' })
+        .run(),
+    ).rejects.toThrow(
+      "The specified variables values file 'non-existing' does not exist",
+    );
+  });
 
-test('fails if additional arguments contain managed params', async () => {
-  await expect(
-    runner()
-      .withWorkflow({ file: workflowPath('always_passing_workflow') })
-      .withAdditionalArgs(
-        '--detect-event',
-        '--input-file',
-        'irrelevant',
-        '--list',
-      )
-      .run(),
-  ).rejects.toThrow(
-    "The following act arguments must be set via dedicated ActRunner methods, and not via 'withAdditionalArguments': --detect-event,--input-file",
-  );
-});
+  test('fails if additional arguments contain managed params', async () => {
+    await expect(
+      runner()
+        .withWorkflow({ file: workflowPath('always_passing_workflow') })
+        .withAdditionalArgs(
+          '--detect-event',
+          '--input-file',
+          'irrelevant',
+          '--list',
+        )
+        .run(),
+    ).rejects.toThrow(
+      "The following act arguments must be set via dedicated ActRunner methods, and not via 'withAdditionalArguments': --detect-event,--input-file",
+    );
+  });
 
-test('fails if additional arguments contain internal params', async () => {
-  await expect(
-    runner()
-      .withWorkflow({ file: workflowPath('always_passing_workflow') })
-      .withAdditionalArgs('--rm')
-      .run(),
-  ).rejects.toThrow(
-    "The following act arguments must not be set via 'withAdditionalArguments', as they are managed by the ActRunner: --rm",
-  );
+  test('fails if additional arguments contain internal params', async () => {
+    await expect(
+      runner()
+        .withWorkflow({ file: workflowPath('always_passing_workflow') })
+        .withAdditionalArgs('--rm')
+        .run(),
+    ).rejects.toThrow(
+      "The following act arguments must not be set via 'withAdditionalArguments', as they are managed by the ActRunner: --rm",
+    );
+  });
 });

--- a/tests/custom_executable.test.ts
+++ b/tests/custom_executable.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { ActExecStatus, ActWorkflowExecResult } from '../src/index.js';
 import { runner, workflowPath } from './fixtures.js';
 import { join } from 'node:path';
@@ -13,80 +13,83 @@ export async function run(executable: string): Promise<ActWorkflowExecResult> {
 }
 
 const customExecDir = join(tmpdir(), 'actTestRunner', 'custom_executable');
-beforeEach(() => {
-  if (!existsSync(customExecDir)) {
-    mkdirSync(customExecDir, { recursive: true });
-  }
-});
 
-afterEach(() => {
-  if (existsSync(customExecDir)) {
-    rmSync(customExecDir, { recursive: true, force: true });
-  }
-});
+describe('custom executable', () => {
+  beforeEach(() => {
+    if (!existsSync(customExecDir)) {
+      mkdirSync(customExecDir, { recursive: true });
+    }
+  });
 
-test('fails if the supplied custom executable does not exist', async () => {
-  await expect(run('non-existing')).rejects.toThrow(
-    "The specified act executable 'non-existing' does not exist",
-  );
-});
+  afterEach(() => {
+    if (existsSync(customExecDir)) {
+      rmSync(customExecDir, { recursive: true, force: true });
+    }
+  });
 
-test('rejects with a clear error if the supplied executable cannot be launched', async () => {
-  // a directory exists on disk but can never be spawned as a process
-  await expect(run(customExecDir)).rejects.toThrow(/Failed to launch act/);
-});
+  test('fails if the supplied custom executable does not exist', async () => {
+    await expect(run('non-existing')).rejects.toThrow(
+      "The specified act executable 'non-existing' does not exist",
+    );
+  });
 
-test('runs workflow files with the supplied custom executable', async () => {
-  const customExec = join(customExecDir, 'customAct');
-  writeFileSync(
-    customExec,
-    `#!/usr/bin/env bash
+  test('rejects with a clear error if the supplied executable cannot be launched', async () => {
+    // a directory exists on disk but can never be spawned as a process
+    await expect(run(customExecDir)).rejects.toThrow(/Failed to launch act/);
+  });
+
+  test('runs workflow files with the supplied custom executable', async () => {
+    const customExec = join(customExecDir, 'customAct');
+    writeFileSync(
+      customExec,
+      `#!/usr/bin/env bash
     echo "Hello from custom act exec!"
   `,
-    { mode: 0o744 },
-  );
-  const result = await run(customExec);
+      { mode: 0o744 },
+    );
+    const result = await run(customExec);
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(result.output).toContain('Hello from custom act exec');
-});
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result.output).toContain('Hello from custom act exec');
+  });
 
-test('rejects if run() is called more than once on the same instance', async () => {
-  const customExec = join(customExecDir, 'customAct');
-  writeFileSync(
-    customExec,
-    `#!/usr/bin/env bash
+  test('rejects if run() is called more than once on the same instance', async () => {
+    const customExec = join(customExecDir, 'customAct');
+    writeFileSync(
+      customExec,
+      `#!/usr/bin/env bash
     echo "Hello from custom act exec!"
   `,
-    { mode: 0o744 },
-  );
-  const testRunner = runner()
-    .withActExecutable(customExec)
-    .withWorkflow({ file: workflowPath('always_passing_workflow') });
+      { mode: 0o744 },
+    );
+    const testRunner = runner()
+      .withActExecutable(customExec)
+      .withWorkflow({ file: workflowPath('always_passing_workflow') });
 
-  await testRunner.run();
+    await testRunner.run();
 
-  await expect(testRunner.run()).rejects.toThrow(
-    'ActRunner instances cannot be reused; create a new instance for each run()',
-  );
-});
+    await expect(testRunner.run()).rejects.toThrow(
+      'ActRunner instances cannot be reused; create a new instance for each run()',
+    );
+  });
 
-test('rejects and kills the process when the abort signal fires', async () => {
-  const customExec = join(customExecDir, 'slowAct');
-  writeFileSync(
-    customExec,
-    `#!/usr/bin/env bash
+  test('rejects and kills the process when the abort signal fires', async () => {
+    const customExec = join(customExecDir, 'slowAct');
+    writeFileSync(
+      customExec,
+      `#!/usr/bin/env bash
     sleep 30
   `,
-    { mode: 0o744 },
-  );
-  const controller = new AbortController();
-  const resultPromise = runner()
-    .withActExecutable(customExec)
-    .withWorkflow({ file: workflowPath('always_passing_workflow') })
-    .run({ signal: controller.signal });
+      { mode: 0o744 },
+    );
+    const controller = new AbortController();
+    const resultPromise = runner()
+      .withActExecutable(customExec)
+      .withWorkflow({ file: workflowPath('always_passing_workflow') })
+      .run({ signal: controller.signal });
 
-  controller.abort();
+    controller.abort();
 
-  await expect(resultPromise).rejects.toThrow('act execution was aborted');
+    await expect(resultPromise).rejects.toThrow('act execution was aborted');
+  });
 });

--- a/tests/utils/checks.test.ts
+++ b/tests/utils/checks.test.ts
@@ -2,43 +2,45 @@ import { describe, test, expect } from 'vitest';
 import { checkExists, checkOneDefined } from '../../src/utils/checks.js';
 import { currentDir } from '../fixtures.js';
 
-describe('checkOneDefined', () => {
-  test('does not fail if first value is defined', () => {
-    expect(() => checkOneDefined('foo', undefined)).not.toThrow();
+describe('checks', () => {
+  describe('checkOneDefined', () => {
+    test('does not fail if first value is defined', () => {
+      expect(() => checkOneDefined('foo', undefined)).not.toThrow();
+    });
+
+    test('does not fail if second value is defined', () => {
+      expect(() => checkOneDefined(undefined, 'bar')).not.toThrow();
+    });
+
+    test('throws if both values are defined', () => {
+      expect(() => checkOneDefined('foo', 'bar')).toThrow(
+        "Expected one value out of 'foo' and 'bar' to be defined",
+      );
+    });
+
+    test('throws if both values are defined', () => {
+      expect(() => checkOneDefined(undefined, undefined)).toThrow(
+        "Expected one value out of 'undefined' and 'undefined' to be defined",
+      );
+    });
   });
 
-  test('does not fail if second value is defined', () => {
-    expect(() => checkOneDefined(undefined, 'bar')).not.toThrow();
-  });
+  describe('checkExists', () => {
+    test('throws if path is not defined', () => {
+      expect(() => checkExists('foo path')).toThrow(
+        'The specified foo path is undefined',
+      );
+    });
 
-  test('throws if both values are defined', () => {
-    expect(() => checkOneDefined('foo', 'bar')).toThrow(
-      "Expected one value out of 'foo' and 'bar' to be defined",
-    );
-  });
+    test('throws if path does not exist', () => {
+      expect(() => checkExists('foo path', 'foo')).toThrow(
+        "The specified foo path 'foo' does not exist",
+      );
+    });
 
-  test('throws if both values are defined', () => {
-    expect(() => checkOneDefined(undefined, undefined)).toThrow(
-      "Expected one value out of 'undefined' and 'undefined' to be defined",
-    );
-  });
-});
-
-describe('checkExists', () => {
-  test('throws if path is not defined', () => {
-    expect(() => checkExists('foo path')).toThrow(
-      'The specified foo path is undefined',
-    );
-  });
-
-  test('throws if path does not exist', () => {
-    expect(() => checkExists('foo path', 'foo')).toThrow(
-      "The specified foo path 'foo' does not exist",
-    );
-  });
-
-  test('returns provided path if it exists', () => {
-    const dir = currentDir();
-    expect(checkExists('current dir', dir)).toBe(dir);
+    test('returns provided path if it exists', () => {
+      const dir = currentDir();
+      expect(checkExists('current dir', dir)).toBe(dir);
+    });
   });
 });

--- a/tests/workflows_artifact_server.test.ts
+++ b/tests/workflows_artifact_server.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { runner, workflowPath } from './fixtures.js';
 import { ActExecStatus, ActRunner } from '../src/index.js';
 import { join } from 'node:path';
@@ -16,35 +16,38 @@ const artifactServerDir = join(
   'actTestRunner',
   'workflows_artifact_server',
 );
-beforeEach(() => {
-  if (!existsSync(artifactServerDir)) {
-    mkdirSync(artifactServerDir, { recursive: true });
-  }
-});
 
-afterEach(() => {
-  if (existsSync(artifactServerDir)) {
-    rmSync(artifactServerDir, { recursive: true, force: true });
-  }
-});
+describe('artifact server', () => {
+  beforeEach(() => {
+    if (!existsSync(artifactServerDir)) {
+      mkdirSync(artifactServerDir, { recursive: true });
+    }
+  });
 
-test('persists workflow artifacts in configured directory', async () => {
-  const result = await artifactServerWorkflowRunner()
-    .withArtifactServer({ path: artifactServerDir })
-    // required to execute upload-artifact action
-    .withEnv({ values: { ACTIONS_RUNTIME_TOKEN: 'irrelevant' } })
-    .run();
+  afterEach(() => {
+    if (existsSync(artifactServerDir)) {
+      rmSync(artifactServerDir, { recursive: true, force: true });
+    }
+  });
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(result.jobs['store_file_in_artifact_server']!.status).toBe(
-    ActExecStatus.SUCCESS,
-  );
+  test('persists workflow artifacts in configured directory', async () => {
+    const result = await artifactServerWorkflowRunner()
+      .withArtifactServer({ path: artifactServerDir })
+      // required to execute upload-artifact action
+      .withEnv({ values: { ACTIONS_RUNTIME_TOKEN: 'irrelevant' } })
+      .run();
 
-  const storedArtifact = join(
-    artifactServerDir,
-    '1',
-    'greeting',
-    'greeting.zip',
-  );
-  expect(existsSync(storedArtifact)).toBe(true);
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result.jobs['store_file_in_artifact_server']!.status).toBe(
+      ActExecStatus.SUCCESS,
+    );
+
+    const storedArtifact = join(
+      artifactServerDir,
+      '1',
+      'greeting',
+      'greeting.zip',
+    );
+    expect(existsSync(storedArtifact)).toBe(true);
+  });
 });

--- a/tests/workflows_cache.test.ts
+++ b/tests/workflows_cache.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { runner, workflowPath } from './fixtures.js';
 import { ActExecStatus, ActRunner } from '../src/index.js';
 import { join } from 'node:path';
@@ -10,28 +10,31 @@ function cacheWorkflowRunner(): ActRunner {
 }
 
 const customCacheDir = join(tmpdir(), 'actTestRunner', 'workflows_cache');
-beforeEach(() => {
-  if (!existsSync(customCacheDir)) {
-    mkdirSync(customCacheDir, { recursive: true });
-  }
+
+describe('cache', () => {
+  beforeEach(() => {
+    if (!existsSync(customCacheDir)) {
+      mkdirSync(customCacheDir, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    if (existsSync(customCacheDir)) {
+      rmSync(customCacheDir, { recursive: true, force: true });
+    }
+  });
+
+  test('persists cache entries in configured directory', async () => {
+    const result = await cacheWorkflowRunner()
+      .withCacheServer({ path: customCacheDir })
+      .run();
+
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result.jobs['store_file_in_cache']!).toHaveStatus(
+      ActExecStatus.SUCCESS,
+    );
+
+    const cacheArtifact = join(customCacheDir, 'cache', '01', '1');
+    expect(existsSync(cacheArtifact)).toBe(true);
+  }, 60_000);
 });
-
-afterEach(() => {
-  if (existsSync(customCacheDir)) {
-    rmSync(customCacheDir, { recursive: true, force: true });
-  }
-});
-
-test('persists cache entries in configured directory', async () => {
-  const result = await cacheWorkflowRunner()
-    .withCacheServer({ path: customCacheDir })
-    .run();
-
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(result.jobs['store_file_in_cache']!).toHaveStatus(
-    ActExecStatus.SUCCESS,
-  );
-
-  const cacheArtifact = join(customCacheDir, 'cache', '01', '1');
-  expect(existsSync(cacheArtifact)).toBe(true);
-}, 60_000);

--- a/tests/workflows_core.test.ts
+++ b/tests/workflows_core.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { ActExecStatus, ActWorkflowExecResult } from '../src/index.js';
 import { runner, workflowPath } from './fixtures.js';
 import { join } from 'node:path';
@@ -12,68 +12,70 @@ export async function run(
 }
 
 const customWorkingDir = join(tmpdir(), 'actTestRunner', 'workflows_core');
-beforeEach(() => {
-  if (!existsSync(customWorkingDir)) {
-    mkdirSync(customWorkingDir, { recursive: true });
-  }
-});
 
-afterEach(() => {
-  if (existsSync(customWorkingDir)) {
-    rmSync(customWorkingDir, { recursive: true, force: true });
-  }
-});
+describe('core', () => {
+  beforeEach(() => {
+    if (!existsSync(customWorkingDir)) {
+      mkdirSync(customWorkingDir, { recursive: true });
+    }
+  });
 
-test('reports successful workflows', async () => {
-  const result = await run(workflowPath('always_passing_workflow'));
+  afterEach(() => {
+    if (existsSync(customWorkingDir)) {
+      rmSync(customWorkingDir, { recursive: true, force: true });
+    }
+  });
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(result.output).toContain('Hello, World!');
-  expect(Object.keys(result.jobs).length).toBe(1);
+  test('reports successful workflows', async () => {
+    const result = await run(workflowPath('always_passing_workflow'));
 
-  const successfulJob = result.jobs['successful_job']!;
-  expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(successfulJob.output).toContain('Hello, World!');
-  expect(successfulJob.matrix).toStrictEqual({});
-});
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result.output).toContain('Hello, World!');
+    expect(Object.keys(result.jobs).length).toBe(1);
 
-test('captures workflow failures', async () => {
-  const result = await run(workflowPath('always_failing_workflow'));
+    const successfulJob = result.jobs['successful_job']!;
+    expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(successfulJob.output).toContain('Hello, World!');
+    expect(successfulJob.matrix).toStrictEqual({});
+  });
 
-  expect(result).toHaveStatus(ActExecStatus.FAILED);
-  expect(result.output).toContain('Hello, World!');
-  expect(Object.keys(result.jobs).length).toBe(1);
+  test('captures workflow failures', async () => {
+    const result = await run(workflowPath('always_failing_workflow'));
 
-  const failingJob = result.jobs['failing_job']!;
-  expect(failingJob).toHaveStatus(ActExecStatus.FAILED);
-  expect(failingJob.output).toContain('Hello, World!');
-});
+    expect(result).toHaveStatus(ActExecStatus.FAILED);
+    expect(result.output).toContain('Hello, World!');
+    expect(Object.keys(result.jobs).length).toBe(1);
 
-test('reports all jobs', async () => {
-  const result = await run(
-    workflowPath('workflow_with_failing_and_passing_jobs'),
-  );
+    const failingJob = result.jobs['failing_job']!;
+    expect(failingJob).toHaveStatus(ActExecStatus.FAILED);
+    expect(failingJob.output).toContain('Hello, World!');
+  });
 
-  expect(result).toHaveStatus(ActExecStatus.FAILED);
-  expect(result.output).toContain('I succeed!');
-  expect(result.output).toContain('I fail!');
-  expect(Object.keys(result.jobs).length).toBe(2);
+  test('reports all jobs', async () => {
+    const result = await run(
+      workflowPath('workflow_with_failing_and_passing_jobs'),
+    );
 
-  const successfulJob = result.jobs['successful_job']!;
-  expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(successfulJob.output).toContain('I succeed!');
-  expect(successfulJob.output).not.toContain('I fail!');
+    expect(result).toHaveStatus(ActExecStatus.FAILED);
+    expect(result.output).toContain('I succeed!');
+    expect(result.output).toContain('I fail!');
+    expect(Object.keys(result.jobs).length).toBe(2);
 
-  const failingJob = result.jobs['failing_job']!;
-  expect(failingJob).toHaveStatus(ActExecStatus.FAILED);
-  expect(failingJob.output).toContain('I fail!');
-  expect(failingJob.output).not.toContain('I succeed!');
-});
+    const successfulJob = result.jobs['successful_job']!;
+    expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(successfulJob.output).toContain('I succeed!');
+    expect(successfulJob.output).not.toContain('I fail!');
 
-test('supports defining workflow body instead of file', async () => {
-  const result = await runner()
-    .withWorkflow({
-      body: `
+    const failingJob = result.jobs['failing_job']!;
+    expect(failingJob).toHaveStatus(ActExecStatus.FAILED);
+    expect(failingJob.output).toContain('I fail!');
+    expect(failingJob.output).not.toContain('I succeed!');
+  });
+
+  test('supports defining workflow body instead of file', async () => {
+    const result = await runner()
+      .withWorkflow({
+        body: `
 name: Simple passing workflow
 on: [push]
 
@@ -84,23 +86,23 @@ jobs:
       - name: Successful step
         run: echo "Hello, World!"
   `,
-    })
-    .run();
+      })
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(result.output).toContain('Hello, World!');
-  expect(Object.keys(result.jobs).length).toBe(1);
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result.output).toContain('Hello, World!');
+    expect(Object.keys(result.jobs).length).toBe(1);
 
-  const successfulJob = result.jobs['successful_job']!;
-  expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(successfulJob.output).toContain('Hello, World!');
-});
+    const successfulJob = result.jobs['successful_job']!;
+    expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(successfulJob.output).toContain('Hello, World!');
+  });
 
-test('supports defining custom working directory', async () => {
-  const result = await runner()
-    .withWorkingDir(customWorkingDir)
-    .withWorkflow({
-      body: `
+  test('supports defining custom working directory', async () => {
+    const result = await runner()
+      .withWorkingDir(customWorkingDir)
+      .withWorkflow({
+        body: `
 name: Simple passing workflow
 on: [push]
 
@@ -111,14 +113,15 @@ jobs:
       - name: Successful step
         run: echo "Hello, World!"
   `,
-    })
-    .run();
+      })
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(result.output).toContain('Hello, World!');
-  expect(Object.keys(result.jobs).length).toBe(1);
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result.output).toContain('Hello, World!');
+    expect(Object.keys(result.jobs).length).toBe(1);
 
-  const successfulJob = result.jobs['successful_job']!;
-  expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(successfulJob.output).toContain('Hello, World!');
+    const successfulJob = result.jobs['successful_job']!;
+    expect(successfulJob).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(successfulJob.output).toContain('Hello, World!');
+  });
 });

--- a/tests/workflows_env.test.ts
+++ b/tests/workflows_env.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 import { inputPath, runner, workflowPath } from './fixtures.js';
 import { ActExecStatus, ActRunner } from '../src/index.js';
 
@@ -6,37 +6,39 @@ function envWorkflowRunner(): ActRunner {
   return runner().withWorkflow({ file: workflowPath('print_env_variables') });
 }
 
-test('supports setting environment variable values directly', async () => {
-  const result = await envWorkflowRunner()
-    .withEnv({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
-    .run();
+describe('env', () => {
+  test('supports setting values directly', async () => {
+    const result = await envWorkflowRunner()
+      .withEnv({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
+      .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
-  const job = result.jobs['print_greeting']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.output).toContain('Hello, Bruce!');
-});
+    expect(result.status).toBe(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hello, Bruce!');
+  });
 
-test('supports setting environment variables from file', async () => {
-  const result = await envWorkflowRunner()
-    .withEnv({ file: inputPath('greeting.env') })
-    .run();
+  test('supports setting values from file', async () => {
+    const result = await envWorkflowRunner()
+      .withEnv({ file: inputPath('greeting.env') })
+      .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
-  const job = result.jobs['print_greeting']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.output).toContain('Hallo, Falco!');
-});
+    expect(result.status).toBe(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hallo, Falco!');
+  });
 
-test('supports combining a values file with inline overrides', async () => {
-  // greeting.env sets GREETING=Hallo, NAME=Falco; NAME is overridden inline
-  // while GREETING is left to come from the file, proving both sources apply
-  const result = await envWorkflowRunner()
-    .withEnv({ file: inputPath('greeting.env'), values: { NAME: 'Bruce' } })
-    .run();
+  test('supports combining a values file with inline overrides', async () => {
+    // greeting.env sets GREETING=Hallo, NAME=Falco; NAME is overridden inline
+    // while GREETING is left to come from the file, proving both sources apply
+    const result = await envWorkflowRunner()
+      .withEnv({ file: inputPath('greeting.env'), values: { NAME: 'Bruce' } })
+      .run();
 
-  expect(result.status).toBe(ActExecStatus.SUCCESS);
-  const job = result.jobs['print_greeting']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.output).toContain('Hallo, Bruce!');
+    expect(result.status).toBe(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hallo, Bruce!');
+  });
 });

--- a/tests/workflows_event.test.ts
+++ b/tests/workflows_event.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 import { eventPayloadPath, runner, workflowPath } from './fixtures.js';
 import { ActExecStatus, ActRunner } from '../src/index.js';
 
@@ -8,60 +8,62 @@ function eventWorkflowRunner(): ActRunner {
   });
 }
 
-test('uses the first event type lexicographically from workflow if no event type is set', async () => {
-  const result = await eventWorkflowRunner().run();
+describe('event', () => {
+  test('uses the first event type lexicographically from workflow if no event type is set', async () => {
+    const result = await eventWorkflowRunner().run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
-  const issueJob = result.jobs['print_issue_title']!;
-  expect(issueJob).toHaveStatus(ActExecStatus.SUCCESS);
+    const issueJob = result.jobs['print_issue_title']!;
+    expect(issueJob).toHaveStatus(ActExecStatus.SUCCESS);
 
-  const prJob = result.jobs['print_pr_title']!;
-  expect(prJob).toHaveStatus(ActExecStatus.SKIPPED);
-});
+    const prJob = result.jobs['print_pr_title']!;
+    expect(prJob).toHaveStatus(ActExecStatus.SKIPPED);
+  });
 
-test('allows configuring the event type to trigger the workflow with', async () => {
-  const result = await eventWorkflowRunner().withEvent('pull_request').run();
+  test('allows configuring the event type to trigger the workflow with', async () => {
+    const result = await eventWorkflowRunner().withEvent('pull_request').run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
-  const issueJob = result.jobs['print_issue_title']!;
-  expect(issueJob).toHaveStatus(ActExecStatus.SKIPPED);
+    const issueJob = result.jobs['print_issue_title']!;
+    expect(issueJob).toHaveStatus(ActExecStatus.SKIPPED);
 
-  const prJob = result.jobs['print_pr_title']!;
-  expect(prJob).toHaveStatus(ActExecStatus.SUCCESS);
-});
+    const prJob = result.jobs['print_pr_title']!;
+    expect(prJob).toHaveStatus(ActExecStatus.SUCCESS);
+  });
 
-test('allows configuring event payload', async () => {
-  const result = await eventWorkflowRunner()
-    .withEvent('pull_request', eventPayloadPath('pull_request_payload'))
-    .run();
+  test('allows configuring event payload', async () => {
+    const result = await eventWorkflowRunner()
+      .withEvent('pull_request', eventPayloadPath('pull_request_payload'))
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
-  const issueJob = result.jobs['print_issue_title']!;
-  expect(issueJob).toHaveStatus(ActExecStatus.SKIPPED);
+    const issueJob = result.jobs['print_issue_title']!;
+    expect(issueJob).toHaveStatus(ActExecStatus.SKIPPED);
 
-  const prJob = result.jobs['print_pr_title']!;
-  expect(prJob).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(prJob.output).toContain('PR Title: Example PR payload');
-});
+    const prJob = result.jobs['print_pr_title']!;
+    expect(prJob).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(prJob.output).toContain('PR Title: Example PR payload');
+  });
 
-test('allows passing event payload as object', async () => {
-  const result = await eventWorkflowRunner()
-    .withEvent('pull_request', {
-      pull_request: {
-        title: 'Example PR payload as object',
-      },
-    })
-    .run();
+  test('allows passing event payload as object', async () => {
+    const result = await eventWorkflowRunner()
+      .withEvent('pull_request', {
+        pull_request: {
+          title: 'Example PR payload as object',
+        },
+      })
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
-  const issueJob = result.jobs['print_issue_title']!;
-  expect(issueJob).toHaveStatus(ActExecStatus.SKIPPED);
+    const issueJob = result.jobs['print_issue_title']!;
+    expect(issueJob).toHaveStatus(ActExecStatus.SKIPPED);
 
-  const prJob = result.jobs['print_pr_title']!;
-  expect(prJob).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(prJob.output).toContain('PR Title: Example PR payload as object');
+    const prJob = result.jobs['print_pr_title']!;
+    expect(prJob).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(prJob.output).toContain('PR Title: Example PR payload as object');
+  });
 });

--- a/tests/workflows_input.test.ts
+++ b/tests/workflows_input.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 import { inputPath, runner, workflowPath } from './fixtures.js';
 import { ActExecStatus, ActRunner } from '../src/index.js';
 
@@ -6,40 +6,42 @@ function inputWorkflowRunner(): ActRunner {
   return runner().withWorkflow({ file: workflowPath('print_inputs') });
 }
 
-test('supports setting input values directly', async () => {
-  const result = await inputWorkflowRunner()
-    .withInputs({ values: { greeting: 'Hello', name: 'Bruce' } })
-    .run();
+describe('inputs', () => {
+  test('supports setting values directly', async () => {
+    const result = await inputWorkflowRunner()
+      .withInputs({ values: { greeting: 'Hello', name: 'Bruce' } })
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.jobs['print_greeting']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.output).toContain('Hello, Bruce!');
-});
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hello, Bruce!');
+  });
 
-test('supports setting input values from file', async () => {
-  const result = await inputWorkflowRunner()
-    .withInputs({ file: inputPath('greeting.input') })
-    .run();
+  test('supports setting values from file', async () => {
+    const result = await inputWorkflowRunner()
+      .withInputs({ file: inputPath('greeting.input') })
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.jobs['print_greeting']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.output).toContain('Hallo, Falco!');
-});
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hallo, Falco!');
+  });
 
-test('supports combining a values file with inline overrides', async () => {
-  // greeting.input sets greeting=Hallo, name=Falco; name is overridden inline
-  // while greeting is left to come from the file, proving both sources apply
-  const result = await inputWorkflowRunner()
-    .withInputs({
-      file: inputPath('greeting.input'),
-      values: { name: 'Bruce' },
-    })
-    .run();
+  test('supports combining a values file with inline overrides', async () => {
+    // greeting.input sets greeting=Hallo, name=Falco; name is overridden inline
+    // while greeting is left to come from the file, proving both sources apply
+    const result = await inputWorkflowRunner()
+      .withInputs({
+        file: inputPath('greeting.input'),
+        values: { name: 'Bruce' },
+      })
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.jobs['print_greeting']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.output).toContain('Hallo, Bruce!');
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hallo, Bruce!');
+  });
 });

--- a/tests/workflows_matrix.test.ts
+++ b/tests/workflows_matrix.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 import { runner, workflowPath } from './fixtures.js';
 import { ActExecStatus, ActRunner } from '../src/index.js';
 
@@ -6,63 +6,73 @@ function matrixWorkflowRunner(): ActRunner {
   return runner().withWorkflow({ file: workflowPath('print_matrix_values') });
 }
 
-test('runs workflow with all matrix values by default', async () => {
-  const result = await matrixWorkflowRunner().run();
+describe('matrix', () => {
+  test('runs workflow with all matrix values by default', async () => {
+    const result = await matrixWorkflowRunner().run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
 
-  const matrixJobs = Object.values(result.jobs);
-  expect(matrixJobs.every((job) => job.status === ActExecStatus.SUCCESS)).toBe(
-    true,
-  );
-  expect(matrixJobs.map((it) => it.name)).toEqual([
-    'print_greeting_1',
-    'print_greeting_2',
-    'print_greeting_3',
-    'print_greeting_4',
-  ]);
+    const matrixJobs = Object.values(result.jobs);
+    expect(
+      matrixJobs.every((job) => job.status === ActExecStatus.SUCCESS),
+    ).toBe(true);
+    expect(matrixJobs.map((it) => it.name)).toEqual([
+      'print_greeting_1',
+      'print_greeting_2',
+      'print_greeting_3',
+      'print_greeting_4',
+    ]);
 
-  const job1 = matrixJobs.find((job) => job.output.includes('Hello, Bruce!'))!;
-  expect(job1.matrix).toStrictEqual({ greeting: 'Hello', name: 'Bruce' });
+    const job1 = matrixJobs.find((job) =>
+      job.output.includes('Hello, Bruce!'),
+    )!;
+    expect(job1.matrix).toStrictEqual({ greeting: 'Hello', name: 'Bruce' });
 
-  const job2 = matrixJobs.find((job) => job.output.includes('Hello, Falco!'))!;
-  expect(job2.matrix).toStrictEqual({ greeting: 'Hello', name: 'Falco' });
+    const job2 = matrixJobs.find((job) =>
+      job.output.includes('Hello, Falco!'),
+    )!;
+    expect(job2.matrix).toStrictEqual({ greeting: 'Hello', name: 'Falco' });
 
-  const job3 = matrixJobs.find((job) => job.output.includes('Hallo, Bruce!'))!;
-  expect(job3.matrix).toStrictEqual({ greeting: 'Hallo', name: 'Bruce' });
+    const job3 = matrixJobs.find((job) =>
+      job.output.includes('Hallo, Bruce!'),
+    )!;
+    expect(job3.matrix).toStrictEqual({ greeting: 'Hallo', name: 'Bruce' });
 
-  const job4 = matrixJobs.find((job) => job.output.includes('Hallo, Falco!'))!;
-  expect(job4.matrix).toStrictEqual({ greeting: 'Hallo', name: 'Falco' });
-});
-
-test('supports restricting matrix values to run with', async () => {
-  const result = await matrixWorkflowRunner()
-    .withMatrix({ greeting: 'Hallo', name: 'Bruce' })
-    .run();
-
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.jobs['print_greeting_1']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.output).toContain('Hallo, Bruce!');
-  expect(job.matrix).toStrictEqual({
-    greeting: 'Hallo',
-    name: 'Bruce',
+    const job4 = matrixJobs.find((job) =>
+      job.output.includes('Hallo, Falco!'),
+    )!;
+    expect(job4.matrix).toStrictEqual({ greeting: 'Hallo', name: 'Falco' });
   });
-});
 
-test('captures all supported matrix value types', async () => {
-  const matrix = {
-    number: 22,
-    string: 'foo',
-    boolean: false,
-  };
-  const result = await runner()
-    .withWorkflow({ file: workflowPath('different_matrix_value_types') })
-    .withMatrix(matrix)
-    .run();
+  test('supports restricting matrix values to run with', async () => {
+    const result = await matrixWorkflowRunner()
+      .withMatrix({ greeting: 'Hallo', name: 'Bruce' })
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.jobs['a_job_1']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.matrix).toStrictEqual(matrix);
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting_1']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hallo, Bruce!');
+    expect(job.matrix).toStrictEqual({
+      greeting: 'Hallo',
+      name: 'Bruce',
+    });
+  });
+
+  test('captures all supported matrix value types', async () => {
+    const matrix = {
+      number: 22,
+      string: 'foo',
+      boolean: false,
+    };
+    const result = await runner()
+      .withWorkflow({ file: workflowPath('different_matrix_value_types') })
+      .withMatrix(matrix)
+      .run();
+
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['a_job_1']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.matrix).toStrictEqual(matrix);
+  });
 });

--- a/tests/workflows_output_listener.test.ts
+++ b/tests/workflows_output_listener.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, vi, afterEach } from 'vitest';
+import { describe, test, expect, vi, afterEach } from 'vitest';
 import {
   ActExecStatus,
   ActOutput,
@@ -38,54 +38,56 @@ const consoleMock = vi
   .mockImplementation(() => undefined);
 const customListener = new CustomOutputListener();
 
-afterEach(() => {
-  consoleMock.mockReset();
-  customListener.clear();
-});
+describe('output listener', () => {
+  afterEach(() => {
+    consoleMock.mockReset();
+    customListener.clear();
+  });
 
-test('does not forward output to console by default', async () => {
-  const result = await runner().withWorkflow({ body: WORKFLOW_BODY }).run();
+  test('does not forward output to console by default', async () => {
+    const result = await runner().withWorkflow({ body: WORKFLOW_BODY }).run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(result.output).toContain('Hello, World!');
-  expect(consoleMock).toHaveBeenCalledTimes(0);
-});
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result.output).toContain('Hello, World!');
+    expect(consoleMock).toHaveBeenCalledTimes(0);
+  });
 
-test('forwards output to console when listener is not provided', async () => {
-  const result = await runner()
-    .withWorkflow({ body: WORKFLOW_BODY })
-    .forwardOutput()
-    .run();
+  test('forwards output to console when listener is not provided', async () => {
+    const result = await runner()
+      .withWorkflow({ body: WORKFLOW_BODY })
+      .forwardOutput()
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(result.output).toContain('Hello, World!');
-  expect(consoleMock).toHaveBeenCalledWith(
-    '[Simple passing workflow/successful_job] Hello, World!',
-  );
-});
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result.output).toContain('Hello, World!');
+    expect(consoleMock).toHaveBeenCalledWith(
+      '[Simple passing workflow/successful_job] Hello, World!',
+    );
+  });
 
-test('forwards output to the specified custom listener', async () => {
-  const result = await runner()
-    .withWorkflow({ body: WORKFLOW_BODY })
-    .forwardOutput(customListener)
-    .run();
+  test('forwards output to the specified custom listener', async () => {
+    const result = await runner()
+      .withWorkflow({ body: WORKFLOW_BODY })
+      .forwardOutput(customListener)
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(result.output).toContain('Hello, World!');
-  expect(consoleMock).toHaveBeenCalledTimes(0);
-  expect(customListener.workflowLogs.length).toBeGreaterThan(0);
-});
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result.output).toContain('Hello, World!');
+    expect(consoleMock).toHaveBeenCalledTimes(0);
+    expect(customListener.workflowLogs.length).toBeGreaterThan(0);
+  });
 
-test('supports combining multiple listeners', async () => {
-  const result = await runner()
-    .withWorkflow({ body: WORKFLOW_BODY })
-    .forwardOutput(customListener, new StdStreamOutputListener())
-    .run();
+  test('supports combining multiple listeners', async () => {
+    const result = await runner()
+      .withWorkflow({ body: WORKFLOW_BODY })
+      .forwardOutput(customListener, new StdStreamOutputListener())
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(result.output).toContain('Hello, World!');
-  expect(consoleMock).toHaveBeenCalledWith(
-    '[Simple passing workflow/successful_job] Hello, World!',
-  );
-  expect(customListener.workflowLogs.length).toBeGreaterThan(0);
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(result.output).toContain('Hello, World!');
+    expect(consoleMock).toHaveBeenCalledWith(
+      '[Simple passing workflow/successful_job] Hello, World!',
+    );
+    expect(customListener.workflowLogs.length).toBeGreaterThan(0);
+  });
 });

--- a/tests/workflows_secrets.test.ts
+++ b/tests/workflows_secrets.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 import { inputPath, runner, workflowPath } from './fixtures.js';
 import { ActExecStatus, ActRunner } from '../src/index.js';
 
@@ -8,41 +8,43 @@ function secretsWorkflowRunner(): ActRunner {
     .withAdditionalArgs('--insecure-secrets');
 }
 
-test('supports setting secrets values directly', async () => {
-  const result = await secretsWorkflowRunner()
-    .withSecrets({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
-    .run();
+describe('secrets', () => {
+  test('supports setting values directly', async () => {
+    const result = await secretsWorkflowRunner()
+      .withSecrets({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.jobs['print_greeting']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.output).toContain('Hello, Bruce!');
-});
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hello, Bruce!');
+  });
 
-test('supports setting secrets values from file', async () => {
-  const result = await secretsWorkflowRunner()
-    .withSecrets({ file: inputPath('greeting.secrets') })
-    .run();
+  test('supports setting values from file', async () => {
+    const result = await secretsWorkflowRunner()
+      .withSecrets({ file: inputPath('greeting.secrets') })
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.jobs['print_greeting']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.output).toContain('Hallo, Falco!');
-});
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hallo, Falco!');
+  });
 
-test('supports combining a values file with inline overrides', async () => {
-  // greeting.secrets sets GREETING=Hallo, NAME=Falco; NAME is overridden
-  // inline while GREETING is left to come from the file, proving both
-  // sources apply
-  const result = await secretsWorkflowRunner()
-    .withSecrets({
-      file: inputPath('greeting.secrets'),
-      values: { NAME: 'Bruce' },
-    })
-    .run();
+  test('supports combining a values file with inline overrides', async () => {
+    // greeting.secrets sets GREETING=Hallo, NAME=Falco; NAME is overridden
+    // inline while GREETING is left to come from the file, proving both
+    // sources apply
+    const result = await secretsWorkflowRunner()
+      .withSecrets({
+        file: inputPath('greeting.secrets'),
+        values: { NAME: 'Bruce' },
+      })
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.jobs['print_greeting']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.output).toContain('Hallo, Bruce!');
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hallo, Bruce!');
+  });
 });

--- a/tests/workflows_variables.test.ts
+++ b/tests/workflows_variables.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 import { inputPath, runner, workflowPath } from './fixtures.js';
 import { ActExecStatus, ActRunner } from '../src/index.js';
 
@@ -6,41 +6,43 @@ function variablesWorkflowRunner(): ActRunner {
   return runner().withWorkflow({ file: workflowPath('print_variables') });
 }
 
-test('supports setting workflow variables directly', async () => {
-  const result = await variablesWorkflowRunner()
-    .withVariables({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
-    .run();
+describe('variables', () => {
+  test('supports setting values directly', async () => {
+    const result = await variablesWorkflowRunner()
+      .withVariables({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.jobs['print_greeting']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.output).toContain('Hello, Bruce!');
-});
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hello, Bruce!');
+  });
 
-test('supports setting workflow variables from file', async () => {
-  const result = await variablesWorkflowRunner()
-    .withVariables({ file: inputPath('greeting.variables') })
-    .run();
+  test('supports setting values from file', async () => {
+    const result = await variablesWorkflowRunner()
+      .withVariables({ file: inputPath('greeting.variables') })
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.jobs['print_greeting']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.output).toContain('Hallo, Falco!');
-});
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hallo, Falco!');
+  });
 
-test('supports combining a values file with inline overrides', async () => {
-  // greeting.variables sets GREETING=Hallo, NAME=Falco; NAME is overridden
-  // inline while GREETING is left to come from the file, proving both
-  // sources apply
-  const result = await variablesWorkflowRunner()
-    .withVariables({
-      file: inputPath('greeting.variables'),
-      values: { NAME: 'Bruce' },
-    })
-    .run();
+  test('supports combining a values file with inline overrides', async () => {
+    // greeting.variables sets GREETING=Hallo, NAME=Falco; NAME is overridden
+    // inline while GREETING is left to come from the file, proving both
+    // sources apply
+    const result = await variablesWorkflowRunner()
+      .withVariables({
+        file: inputPath('greeting.variables'),
+        values: { NAME: 'Bruce' },
+      })
+      .run();
 
-  expect(result).toHaveStatus(ActExecStatus.SUCCESS);
-  const job = result.jobs['print_greeting']!;
-  expect(job).toHaveStatus(ActExecStatus.SUCCESS);
-  expect(job.output).toContain('Hallo, Bruce!');
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hallo, Bruce!');
+  });
 });


### PR DESCRIPTION
## Summary
- Wraps all top-level `test()` calls in every test file under a single top-level `describe()` block, so IDE test runners that can only execute `describe`/`test` blocks (not whole files) can now run an entire file's tests at once.
- `tests/utils/checks.test.ts` gets an outer `describe('checks', ...)` wrapping its existing `checkOneDefined`/`checkExists` describes; `tests/utils/fsutils.test.ts` and `tests/utils/objects.test.ts` already had a single top-level `describe` covering all their tests, so they were left unchanged.
- Trimmed a few test names that became redundant once nested under their new describe block (e.g. "supports setting environment variable values directly" → "supports setting values directly" under `describe('env', ...)`).
- No behavioral changes — same tests, same assertions, just regrouped.

## Test plan
- [x] `pnpm run lint:check`
- [x] `pnpm run prettier:check`
- [x] `pnpm run types:check`
- [x] `pnpm run test` — the tests that don't require the `act`/Docker toolchain (config validation, custom executable validation, utils) pass; the workflow-execution tests that spawn `act` cannot run in this sandbox (no `act` binary available) but are structurally unchanged aside from the new `describe` wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMTdkdcACC4i47bmzJUfL9

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMTdkdcACC4i47bmzJUfL9)_