### PR TITLE
fix: make withEnv and similar builder methods override instead of merge

### DIFF
--- a/src/ActRunner.ts
+++ b/src/ActRunner.ts
@@ -79,18 +79,11 @@ export class ActRunner<
   private workflowSource: ActWorkflowSource | undefined;
   private eventType: TEventType | undefined;
   private eventPayloadFileOrBody: TEventPayload | undefined;
-  private envFile: string | undefined;
-  private envValues: Map<string, string> = new Map<string, string>();
-  private inputsFile: string | undefined;
-  private inputsValues: Map<string, string> = new Map<string, string>();
-  private secretsFile: string | undefined;
-  private secretsValues: Map<string, string> = new Map<string, string>();
-  private variablesFile: string | undefined;
-  private variablesValues: Map<string, string> = new Map<string, string>();
-  private matrix: Map<string, string | number | boolean> = new Map<
-    string,
-    string | number | boolean
-  >();
+  private envSource: ActValueSource | undefined;
+  private inputsSource: ActValueSource | undefined;
+  private secretsSource: ActValueSource | undefined;
+  private variablesSource: ActValueSource | undefined;
+  private matrixValues: ActMatrixValues | undefined;
   private cacheServer: ActResourceServerSpec | undefined;
   private artifactServer: ActResourceServerSpec | undefined;
   private additionalArgs: string[] = [];
@@ -142,62 +135,52 @@ export class ActRunner<
 
   /**
    * Specifies environment variables to use when invoking the given workflow, provided via a file, inline values, or both.
+   * Replaces any environment variables set by a previous call to this method.
    * @param source - environment variables source
    */
   withEnv(source: ActValueSource): this {
-    this.envFile = source.file;
-    this.setValues(this.envValues, source.values);
+    this.envSource = source;
     return this;
   }
 
   /**
    * Specifies inputs values to use when invoking the given workflow, provided via a file, inline values, or both.
+   * Replaces any inputs values set by a previous call to this method.
    * @param source - inputs values source
    */
   withInputs(source: ActValueSource): this {
-    this.inputsFile = source.file;
-    this.setValues(this.inputsValues, source.values);
+    this.inputsSource = source;
     return this;
   }
 
   /**
    * Specifies secrets values to use when invoking the given workflow, provided via a file, inline values, or both.
+   * Replaces any secrets values set by a previous call to this method.
    * @param source - secrets values source
    */
   withSecrets(source: ActValueSource): this {
-    this.secretsFile = source.file;
-    this.setValues(this.secretsValues, source.values);
+    this.secretsSource = source;
     return this;
   }
 
   /**
    * Specifies workflow variables values to use when invoking the given workflow, provided via a file, inline values, or both.
+   * Replaces any variables values set by a previous call to this method.
    * @param source - variables values source
    */
   withVariables(source: ActValueSource): this {
-    this.variablesFile = source.file;
-    this.setValues(this.variablesValues, source.values);
+    this.variablesSource = source;
     return this;
-  }
-
-  private setValues(
-    target: Map<string, string>,
-    values: Record<string, string> | undefined,
-  ): void {
-    if (values !== undefined) {
-      Object.entries(values).forEach(([key, value]) => target.set(key, value));
-    }
   }
 
   /**
    * Set matrix values to run the workflow with.
    * If undefined, all combinations specified in the workflow definition will be invoked.
+   * Replaces any matrix values set by a previous call to this method.
    * @param matrixValues - matrix values to run the workflow with
    */
   withMatrix(matrixValues: ActMatrixValues): this {
-    Object.entries(matrixValues).forEach(([key, value]) =>
-      this.matrix.set(key, value),
-    );
+    this.matrixValues = matrixValues;
     return this;
   }
 
@@ -373,15 +356,11 @@ export class ActRunner<
       workflowsPath: workflowFilePath,
       eventPayloadFilePath,
       eventType: this.eventType,
-      envFile: this.envFile,
-      envValues: this.envValues,
-      inputFile: this.inputsFile,
-      inputValues: this.inputsValues,
-      secretsFile: this.secretsFile,
-      secretsValues: this.secretsValues,
-      variablesFile: this.variablesFile,
-      variablesValues: this.variablesValues,
-      matrix: this.matrix,
+      envSource: this.envSource,
+      inputsSource: this.inputsSource,
+      secretsSource: this.secretsSource,
+      variablesSource: this.variablesSource,
+      matrixValues: this.matrixValues,
       cacheServer: this.cacheServer,
       artifactServer: this.artifactServer,
       additionalArgs: this.additionalArgs,

--- a/src/internal/ActCliParams.ts
+++ b/src/internal/ActCliParams.ts
@@ -20,7 +20,11 @@
  */
 
 import { WebhookEventName } from '@octokit/webhooks-types';
-import type { ActResourceServerSpec } from '../ActRunnerOptions.js';
+import type {
+  ActResourceServerSpec,
+  ActValueSource,
+} from '../ActRunnerOptions.js';
+import type { ActMatrixValues } from '../ActRunnerResult.js';
 import { checkExists } from '../utils/checks.js';
 import { firstDefined } from '../utils/objects.js';
 
@@ -56,15 +60,11 @@ export type ActCliParamsInput<
   workflowsPath: string;
   eventPayloadFilePath: string | undefined;
   eventType: EventType | undefined;
-  envFile: string | undefined;
-  envValues: Map<string, string>;
-  inputFile: string | undefined;
-  inputValues: Map<string, string>;
-  secretsFile: string | undefined;
-  secretsValues: Map<string, string>;
-  variablesFile: string | undefined;
-  variablesValues: Map<string, string>;
-  matrix: Map<string, string | number | boolean>;
+  envSource: ActValueSource | undefined;
+  inputsSource: ActValueSource | undefined;
+  secretsSource: ActValueSource | undefined;
+  variablesSource: ActValueSource | undefined;
+  matrixValues: ActMatrixValues | undefined;
   cacheServer: ActResourceServerSpec | undefined;
   artifactServer: ActResourceServerSpec | undefined;
   additionalArgs: string[];
@@ -76,15 +76,11 @@ export class ActCliParams<
   private readonly workflowsPath: string;
   private readonly eventPayloadFilePath: string | undefined;
   private readonly eventType: EventType | undefined;
-  private readonly envFile: string | undefined;
-  private readonly envValues: Map<string, string>;
-  private readonly inputFile: string | undefined;
-  private readonly inputValues: Map<string, string>;
-  private readonly secretsFile: string | undefined;
-  private readonly secretsValues: Map<string, string>;
-  private readonly variablesFile: string | undefined;
-  private readonly variablesValues: Map<string, string>;
-  private readonly matrix: Map<string, string | number | boolean>;
+  private readonly envSource: ActValueSource | undefined;
+  private readonly inputsSource: ActValueSource | undefined;
+  private readonly secretsSource: ActValueSource | undefined;
+  private readonly variablesSource: ActValueSource | undefined;
+  private readonly matrixValues: ActMatrixValues | undefined;
   private readonly cacheServer: ActResourceServerSpec | undefined;
   private readonly artifactServer: ActResourceServerSpec | undefined;
   private readonly additionalArgs: string[];
@@ -93,15 +89,11 @@ export class ActCliParams<
     this.workflowsPath = params.workflowsPath;
     this.eventType = params.eventType;
     this.eventPayloadFilePath = params.eventPayloadFilePath;
-    this.envFile = params.envFile;
-    this.envValues = params.envValues;
-    this.inputFile = params.inputFile;
-    this.inputValues = params.inputValues;
-    this.secretsFile = params.secretsFile;
-    this.secretsValues = params.secretsValues;
-    this.variablesFile = params.variablesFile;
-    this.variablesValues = params.variablesValues;
-    this.matrix = params.matrix;
+    this.envSource = params.envSource;
+    this.inputsSource = params.inputsSource;
+    this.secretsSource = params.secretsSource;
+    this.variablesSource = params.variablesSource;
+    this.matrixValues = params.matrixValues;
     this.cacheServer = params.cacheServer;
     this.artifactServer = params.artifactServer;
     this.additionalArgs = params.additionalArgs;
@@ -115,40 +107,36 @@ export class ActCliParams<
     this.addInputs(
       args,
       '--env-file',
-      this.envFile,
       'env values file',
       '--env',
-      this.envValues,
+      this.envSource,
     );
 
     this.addInputs(
       args,
       '--input-file',
-      this.inputFile,
       'input values file',
       '--input',
-      this.inputValues,
+      this.inputsSource,
     );
 
     this.addInputs(
       args,
       '--secret-file',
-      this.secretsFile,
       'secrets values file',
       '--secret',
-      this.secretsValues,
+      this.secretsSource,
     );
 
     this.addInputs(
       args,
       '--var-file',
-      this.variablesFile,
       'variables values file',
       '--var',
-      this.variablesValues,
+      this.variablesSource,
     );
 
-    this.matrix.forEach((value, key) => {
+    Object.entries(this.matrixValues ?? {}).forEach(([key, value]) => {
       args.push('--matrix');
       args.push(`${key}:${value}`);
     });
@@ -194,21 +182,18 @@ export class ActCliParams<
   private addInputs(
     args: string[],
     fileArg: string,
-    file: string | undefined,
     fileLabel: string,
     valuesArg: string,
-    values: Map<string, string>,
+    source: ActValueSource | undefined,
   ) {
-    if (file !== undefined) {
-      checkExists(fileLabel, file);
-      args.push(fileArg, file);
+    if (source?.file !== undefined) {
+      checkExists(fileLabel, source.file);
+      args.push(fileArg, source.file);
     }
 
-    if (values.size > 0) {
-      values.forEach((value, key) => {
-        args.push(valuesArg, `${key}=${value}`);
-      });
-    }
+    Object.entries(source?.values ?? {}).forEach(([key, value]) => {
+      args.push(valuesArg, `${key}=${value}`);
+    });
   }
 
   private addResource(

--- a/tests/workflows_env.test.ts
+++ b/tests/workflows_env.test.ts
@@ -41,4 +41,16 @@ describe('env', () => {
     expect(job).toHaveStatus(ActExecStatus.SUCCESS);
     expect(job.output).toContain('Hallo, Bruce!');
   });
+
+  test('a later call to withEnv replaces values set by an earlier call', async () => {
+    const result = await envWorkflowRunner()
+      .withEnv({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
+      .withEnv({ values: { GREETING: 'Hallo' } })
+      .run();
+
+    expect(result.status).toBe(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hallo, !');
+  });
 });

--- a/tests/workflows_input.test.ts
+++ b/tests/workflows_input.test.ts
@@ -44,4 +44,16 @@ describe('inputs', () => {
     expect(job).toHaveStatus(ActExecStatus.SUCCESS);
     expect(job.output).toContain('Hallo, Bruce!');
   });
+
+  test('a later call to withInputs replaces values set by an earlier call', async () => {
+    const result = await inputWorkflowRunner()
+      .withInputs({ values: { greeting: 'Hello', name: 'Bruce' } })
+      .withInputs({ values: { greeting: 'Hallo', name: 'Falco' } })
+      .run();
+
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hallo, Falco!');
+  });
 });

--- a/tests/workflows_matrix.test.ts
+++ b/tests/workflows_matrix.test.ts
@@ -59,6 +59,24 @@ describe('matrix', () => {
     });
   });
 
+  test('a later call to withMatrix replaces values set by an earlier call', async () => {
+    const result = await matrixWorkflowRunner()
+      .withMatrix({ greeting: 'Hallo', name: 'Bruce' })
+      .withMatrix({ greeting: 'Hello' })
+      .run();
+
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+
+    const matrixJobs = Object.values(result.jobs);
+    expect(
+      matrixJobs.every((job) => job.status === ActExecStatus.SUCCESS),
+    ).toBe(true);
+    expect(matrixJobs.map((it) => it.matrix)).toEqual([
+      { greeting: 'Hello', name: 'Bruce' },
+      { greeting: 'Hello', name: 'Falco' },
+    ]);
+  });
+
   test('captures all supported matrix value types', async () => {
     const matrix = {
       number: 22,

--- a/tests/workflows_secrets.test.ts
+++ b/tests/workflows_secrets.test.ts
@@ -47,4 +47,16 @@ describe('secrets', () => {
     expect(job).toHaveStatus(ActExecStatus.SUCCESS);
     expect(job.output).toContain('Hallo, Bruce!');
   });
+
+  test('a later call to withSecrets replaces values set by an earlier call', async () => {
+    const result = await secretsWorkflowRunner()
+      .withSecrets({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
+      .withSecrets({ values: { GREETING: 'Hallo' } })
+      .run();
+
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hallo, !');
+  });
 });

--- a/tests/workflows_variables.test.ts
+++ b/tests/workflows_variables.test.ts
@@ -45,4 +45,16 @@ describe('variables', () => {
     expect(job).toHaveStatus(ActExecStatus.SUCCESS);
     expect(job.output).toContain('Hallo, Bruce!');
   });
+
+  test('a later call to withVariables replaces values set by an earlier call', async () => {
+    const result = await variablesWorkflowRunner()
+      .withVariables({ values: { GREETING: 'Hello', NAME: 'Bruce' } })
+      .withVariables({ values: { GREETING: 'Hallo' } })
+      .run();
+
+    expect(result).toHaveStatus(ActExecStatus.SUCCESS);
+    const job = result.jobs['print_greeting']!;
+    expect(job).toHaveStatus(ActExecStatus.SUCCESS);
+    expect(job.output).toContain('Hallo, !');
+  });
 });


### PR DESCRIPTION
## Summary
- `withEnv`, `withInputs`, `withSecrets`, `withVariables`, and `withMatrix` used to merge values from a new call into whatever was already set by a previous call, so a later call could never fully clear out earlier configuration.
- Each of these methods now simply stores the `ActValueSource` (or `ActMatrixValues`) it was given, so a later call fully replaces the previous one instead of merging into it.
- `ActCliParams` now carries the `ActValueSource`/`ActMatrixValues` through as-is and only unpacks `file`/`values` when building the `act` CLI args in `asCliArgs()`, rather than unpacking them earlier in `ActRunner`.

## Test plan
- [x] `pnpm run types:check`
- [x] `pnpm run lint:check`
- [x] `pnpm run prettier:check`
- [x] Added regression tests to `workflows_env`, `workflows_input`, `workflows_secrets`, `workflows_variables`, and `workflows_matrix` verifying a second `with*` call overrides rather than merges with the first
- [ ] Full `pnpm run test` (workflow-execution tests) — could not run locally, this sandbox has no `act` binary or running Docker daemon; needs CI or a local machine with `act`/Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLqC1dWnGKJ7KkFzaDuEPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLqC1dWnGKJ7KkFzaDuEPY)_